### PR TITLE
Allow to skip the geometries

### DIFF
--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -26,6 +26,9 @@ struct Args {
     output: Option<String>,
     #[structopt(long = "print-stats", default_value = "true")]
     print_stats: bool,
+    #[structopt(help = "Do not read the geometry of the boundaries", long = "disable-geom",
+                default_value = "false")]
+    disable_geom: bool,
 }
 
 fn serialize_to_json(cosmogony: &Cosmogony, output_file: String) -> Result<(), Error> {
@@ -37,7 +40,7 @@ fn serialize_to_json(cosmogony: &Cosmogony, output_file: String) -> Result<(), E
 }
 
 fn cosmogony(args: Args) -> Result<(), Error> {
-    let cosmogony = build_cosmogony(args.input)?;
+    let cosmogony = build_cosmogony(args.input, !args.disable_geom)?;
 
     if let Some(output) = args.output {
         serialize_to_json(&cosmogony, output)?;

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -21,6 +21,19 @@ pub struct CosmogonyStats {
     pub wikidata_counts: BTreeMap<u32, u64>,
 }
 
+impl CosmogonyStats {
+    pub fn process(&mut self, zone: &Zone) {
+        zone.admin_level.map(|level| {
+            let count = self.level_counts.entry(level).or_insert(0);
+            *count += 1;
+            if zone.wikidata.is_some() {
+                let wd_count = self.wikidata_counts.entry(level).or_insert(0);
+                *wd_count += 1;
+            }
+        });
+    }
+}
+
 impl fmt::Display for CosmogonyStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (level, count) in &self.level_counts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,7 @@
 extern crate failure;
-extern crate geo;
-extern crate geojson;
-extern crate itertools;
 #[macro_use]
 extern crate log;
-extern crate mimir;
-extern crate mimirsbrunn;
 extern crate osmpbfreader;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
@@ -17,18 +11,16 @@ pub mod cosmogony;
 
 use std::fs::File;
 use std::path::Path;
-use mimirsbrunn::osm_reader::OsmPbfReader;
-use itertools::Itertools;
-use mimirsbrunn::boundaries::{build_boundary, make_centroid};
 use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
+use osmpbfreader::{OsmObj, OsmPbfReader};
 
 use failure::Error;
 use failure::ResultExt;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-pub fn is_admin(obj: &osmpbfreader::OsmObj) -> bool {
+pub fn is_admin(obj: &OsmObj) -> bool {
     match *obj {
-        osmpbfreader::OsmObj::Relation(ref rel) => {
+        OsmObj::Relation(ref rel) => {
             rel.tags
                 .get("boundary")
                 .map_or(false, |v| v == "administrative")
@@ -40,9 +32,9 @@ pub fn is_admin(obj: &osmpbfreader::OsmObj) -> bool {
 }
 
 pub fn get_zones_and_stats(
-    pbf: &mut OsmPbfReader,
+    pbf: &mut OsmPbfReader<File>,
 ) -> Result<(Vec<zone::Zone>, CosmogonyStats), Error> {
-    info!("reading pbf...");
+    info!("Reading pbf with geometries...");
     let objects = pbf.get_objs_and_deps(|o| is_admin(o))
         .context("invalid osm file")?;
     info!("reading pbf done.");
@@ -54,84 +46,54 @@ pub fn get_zones_and_stats(
         if !is_admin(obj) {
             continue;
         }
-        if let osmpbfreader::OsmObj::Relation(ref relation) = *obj {
-            let level = relation
-                .tags
-                .get("admin_level")
-                .and_then(|s| s.parse().ok());
-
-            // Skip administrative region without name
-            let name = match relation.tags.get("name") {
-                Some(val) => val,
-                None => {
-                    warn!(
-                        "relation/{}: adminstrative region without name, skipped",
-                        relation.id.0
-                    );
-                    continue;
+        if let OsmObj::Relation(ref relation) = *obj {
+            if let Some(zone) = zone::Zone::from_osm_with_geom(relation, &objects) {
+                // Ignore zone without boundary polygon
+                if zone.boundary.is_some() {
+                    stats.process(&zone);
+                    zones.push(zone);
                 }
-            };
-
-            let coord_center = relation
-                .refs
-                .iter()
-                .find(|r| r.role == "admin_centre")
-                .and_then(|r| objects.get(&r.member))
-                .and_then(|o| o.node())
-                .map(|node| mimir::Coord::new(node.lat(), node.lon()));
-            let zip_code = relation
-                .tags
-                .get("addr:postcode")
-                .or_else(|| relation.tags.get("postal_code"))
-                .map_or("", |val| &val[..]);
-            let zip_codes = zip_code
-                .split(';')
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-                .sorted();
-            let wikidata = relation.tags.get("wikidata").map(|s| s.to_string());
-            let boundary = build_boundary(relation, &objects);
-            let zone = zone::Zone {
-                id: relation.id.0.to_string(),
-                admin_level: level,
-                admin_type: None,
-                name: name.to_string(),
-                zip_codes: zip_codes,
-                center: coord_center.unwrap_or_else(|| make_centroid(&boundary)),
-                boundary: boundary,
-                parent: None,
-                tags: vec![],
-                wikidata: wikidata,
-            };
-
-            // Ignore zone without boundary polygon
-            if zone.boundary.is_none() {
-                continue;
             }
-
-            zone.admin_level.map(|level| {
-                let count = stats.level_counts.entry(level).or_insert(0);
-                *count += 1;
-                if zone.wikidata.is_some() {
-                    let wd_count = stats.wikidata_counts.entry(level).or_insert(0);
-                    *wd_count += 1;
-                }
-            });
-
-            zones.push(zone);
         }
     }
 
     return Ok((zones, stats));
 }
 
-pub fn build_cosmogony(pbf_path: String) -> Result<Cosmogony, Error> {
+pub fn get_zones_and_stats_without_geom(
+    pbf: &mut OsmPbfReader<File>,
+) -> Result<(Vec<zone::Zone>, CosmogonyStats), Error> {
+    info!("Reading pbf without geometries...");
+
+    let mut zones = vec![];
+    let mut stats = CosmogonyStats::default();
+
+    for obj in pbf.par_iter().map(Result::unwrap) {
+        if !is_admin(&obj) {
+            continue;
+        }
+        if let OsmObj::Relation(ref relation) = obj {
+            if let Some(zone) = zone::Zone::from_osm(relation) {
+                stats.process(&zone);
+                zones.push(zone);
+            }
+        }
+    }
+
+    Ok((zones, stats))
+}
+
+pub fn build_cosmogony(pbf_path: String, with_geom: bool) -> Result<Cosmogony, Error> {
     let path = Path::new(&pbf_path);
     let file = File::open(&path).context("no pbf file")?;
 
-    let mut parsed_pbf = osmpbfreader::OsmPbfReader::new(file);
+    let mut parsed_pbf = OsmPbfReader::new(file);
 
-    let (zones, stats) = get_zones_and_stats(&mut parsed_pbf)?;
+    let (zones, stats) = if with_geom {
+        get_zones_and_stats(&mut parsed_pbf)?
+    } else {
+        get_zones_and_stats_without_geom(&mut parsed_pbf)?
+    };
     let cosmogony = Cosmogony {
         zones: zones,
         meta: CosmogonyMetadata {

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -12,7 +12,7 @@ fn read_lux_admin_levels() {
         env!("OUT_DIR"),
         "/../../../../../tests/data/luxembourg_filtered.osm.pbf"
     );
-    let cosmogony = cosmogony::build_cosmogony(test_file.into()).expect("invalid cosmogony");
+    let cosmogony = cosmogony::build_cosmogony(test_file.into(), true).expect("invalid cosmogony");
     assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
 
     let level_counts = cosmogony.meta.stats.level_counts;


### PR DESCRIPTION
When only working on the metadata, it allows to save some time and a lot of memory.

For instance, for France, the read time goes down from 8 minutes to 2, and the memory usage from 2,6Gb down to 200Mb