### PR TITLE
Implement zones containment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,10 +177,18 @@ dependencies = [
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geos 0.0.1 (git+https://github.com/amatissart/rust-geos.git)",
+ "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+<<<<<<< HEAD
  "mimir 1.2.0",
  "mimirsbrunn 1.2.0",
+=======
+ "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "mimirsbrunn 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
+ "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+>>>>>>> Implement zones containment
  "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -302,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -310,7 +318,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -336,9 +344,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "geos"
+version = "0.0.1"
+source = "git+https://github.com/amatissart/rust-geos.git#25396649fa0f62c487576913e3b799ca9dcac84c"
+dependencies = [
+ "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "get-corresponding-derive"
 version = "0.1.0"
-source = "git+https://github.com/CanalTP/navitia_model#8dae885e2aef2c06e08c8edcd6260fe394532d29"
+source = "git+https://github.com/CanalTP/navitia_model#a8216f04a9fae8d57a2e91920fb6b882067b4284"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -620,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "navitia_model"
 version = "0.1.0"
-source = "git+https://github.com/CanalTP/navitia_model#8dae885e2aef2c06e08c8edcd6260fe394532d29"
+source = "git+https://github.com/CanalTP/navitia_model#a8216f04a9fae8d57a2e91920fb6b882067b4284"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -629,7 +647,6 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -758,7 +775,7 @@ name = "par-map"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pub-iterator-type 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1121,14 +1138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "termcolor"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,10 +1425,11 @@ dependencies = [
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "03421e9865903f0015426358027cafe76d4a3858031adaa1a1f1be5e62cdbb82"
 "checksum geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7e92af77b6bd45cf336b9f77d73218d9cff1b040aedd3c344e091d6c31dbed"
+"checksum geos 0.0.1 (git+https://github.com/amatissart/rust-geos.git)" = "<none>"
 "checksum get-corresponding-derive 0.1.0 (git+https://github.com/CanalTP/navitia_model)" = "<none>"
 "checksum gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89d64d16c4e0ab924799d713bf939dd16a2e9d3e71afe9f2b2977f38a04e0188"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
@@ -1508,7 +1518,6 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
-"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9065bced9c3e43453aa3d56f1e98590b8455b341d2fa191a1090c0dd0b242c75"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,12 +88,13 @@ dependencies = [
 [[package]]
 name = "bragi"
 version = "1.2.0"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git#474972c1b0547d99bea8e8c74e10c499f81c10b5"
 dependencies = [
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0",
+ "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -181,14 +182,9 @@ dependencies = [
  "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-<<<<<<< HEAD
- "mimir 1.2.0",
- "mimirsbrunn 1.2.0",
-=======
  "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "mimirsbrunn 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
->>>>>>> Implement zones containment
  "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -346,7 +342,7 @@ dependencies = [
 [[package]]
 name = "geos"
 version = "0.0.1"
-source = "git+https://github.com/amatissart/rust-geos.git#25396649fa0f62c487576913e3b799ca9dcac84c"
+source = "git+https://github.com/amatissart/rust-geos.git#851afd3ea74f5e45e0dde368302d48380d328a52"
 dependencies = [
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,7 +352,7 @@ dependencies = [
 [[package]]
 name = "get-corresponding-derive"
 version = "0.1.0"
-source = "git+https://github.com/CanalTP/navitia_model#a8216f04a9fae8d57a2e91920fb6b882067b4284"
+source = "git+https://github.com/CanalTP/navitia_model#9bfad39f2700710c62545dce1c4858cd2c825ad1"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -521,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -582,6 +578,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "1.2.0"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git#474972c1b0547d99bea8e8c74e10c499f81c10b5"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -598,21 +595,22 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "1.2.0"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git#474972c1b0547d99bea8e8c74e10c499f81c10b5"
 dependencies = [
- "bragi 1.2.0",
+ "bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mdo 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mimir 1.2.0",
+ "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "osm_builder 1.2.0",
+ "osm_builder 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -638,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "navitia_model"
 version = "0.1.0"
-source = "git+https://github.com/CanalTP/navitia_model#a8216f04a9fae8d57a2e91920fb6b882067b4284"
+source = "git+https://github.com/CanalTP/navitia_model#9bfad39f2700710c62545dce1c4858cd2c825ad1"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,7 +661,7 @@ dependencies = [
  "num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -706,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,8 +750,9 @@ dependencies = [
 [[package]]
 name = "osm_builder"
 version = "1.2.0"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git#474972c1b0547d99bea8e8c74e10c499f81c10b5"
 dependencies = [
- "mimir 1.2.0",
+ "mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)",
  "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1054,7 +1053,7 @@ name = "serde_yaml"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1389,7 +1388,7 @@ name = "yaml-rust"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -1403,6 +1402,7 @@ dependencies = [
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
+"checksum bragi 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
@@ -1449,7 +1449,7 @@ dependencies = [
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
-"checksum linked-hash-map 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2aab0478615bb586559b0114d94dd8eca4fdbb73b443adcb0d00b61692b4bf"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
@@ -1458,6 +1458,8 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+"checksum mimir 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
+"checksum mimirsbrunn 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)" = "<none>"
@@ -1467,12 +1469,13 @@ dependencies = [
 "checksum num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "58de7b4bf7cf5dbecb635a5797d489864eadd03b107930cbccf9e0fd7428b47c"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
-"checksum num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7cb72a95250d8a370105c828f388932373e0e94414919891a0f945222310fe"
+"checksum num-rational 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "0b950f75e042fdd710460084d19c8efdcd72d65183ead8ecd04b90483f5a55d2"
 "checksum num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9936036cc70fe4a8b2d338ab665900323290efb03983c86cbe235ae800ad8017"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e312d9bf410688e9c292d9e7da4567143c0ad18df8fceb6ce99156f40cef2"
+"checksum osm_builder 1.2.0 (git+https://github.com/CanalTP/mimirsbrunn.git)" = "<none>"
 "checksum osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee6ac019a0e2e42e3a982dad2205b7ea61a65592ceecc4b565f405e824864962"
 "checksum par-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a148044b62c5002054d4a164b352cf1439fffed060073703e08ba0863d56fdaf"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 log = "0.4"
-geo = "0.4.7"
+geo = "0.4"
 mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
 mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
 structopt = "0.1"
@@ -20,3 +20,6 @@ itertools = "*"
 geojson = "0.8"
 failure = "0.1"
 failure_derive = "0.1"
+gst = "0.1.3"
+ordered-float = "0.0.2"
+geos = { git = "https://github.com/amatissart/rust-geos.git" }

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use zone::Zone;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Cosmogony {
     pub zones: Vec<Zone>,
     pub meta: CosmogonyMetadata,

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -1,0 +1,225 @@
+extern crate geo;
+
+use std::iter::FromIterator;
+use zone::{Zone, ZoneIndex};
+use gst::rtree::{RTree, Rect};
+use ordered_float::OrderedFloat;
+use geo::Bbox;
+use geo::boundingbox::BoundingBox;
+
+pub struct ZonesTree {
+    tree: RTree<ZoneIndex>,
+}
+
+impl Default for ZonesTree {
+    fn default() -> Self {
+        ZonesTree { tree: RTree::new() }
+    }
+}
+
+impl ZonesTree {
+    pub fn insert_zone(&mut self, z: &Zone) {
+        if let Some(ref b) = z.boundary {
+            match b.bbox() {
+                Some(b) => self.tree.insert(bbox_to_rect(b), z.id.clone()),
+                None => warn!("No bbox: Cannot insert zone with osm_id {}", z.osm_id),
+            }
+        }
+    }
+
+    pub fn fetch_zone_bbox(&self, z: &Zone) -> Vec<ZoneIndex> {
+        match z.boundary {
+            None => vec![],
+            Some(ref b) => {
+                if let Some(bbox) = b.bbox() {
+                    self.tree
+                        .get(&bbox_to_rect(bbox))
+                        .into_iter()
+                        .map(|(_, z_idx)| z_idx.clone())
+                        .collect()
+                } else {
+                    warn!("No bbox: Cannot fetch zone with osm_id {}", z.osm_id);
+                    vec![]
+                }
+            }
+        }
+    }
+}
+
+impl<'a> FromIterator<&'a Zone> for ZonesTree {
+    fn from_iter<I: IntoIterator<Item = &'a Zone>>(zones: I) -> Self {
+        let mut ztree = ZonesTree::default();
+        for z in zones {
+            ztree.insert_zone(z);
+        }
+        ztree
+    }
+}
+
+pub fn bbox_to_rect(bbox: Bbox<f64>) -> Rect {
+    // rust-geo bbox algorithm returns `Bbox`,
+    // while gst RTree uses `Rect` as index.
+    Rect {
+        xmin: OrderedFloat(down(bbox.xmin as f32)),
+        xmax: OrderedFloat(up(bbox.xmax as f32)),
+        ymin: OrderedFloat(down(bbox.ymin as f32)),
+        ymax: OrderedFloat(up(bbox.ymax as f32)),
+    }
+}
+
+pub fn build_hierarchy(zones: &mut [Zone]) {
+    let ztree: ZonesTree = zones.iter().collect();
+    let nb_zones = zones.len();
+
+    for i in 0..nb_zones {
+        let (mslice, z1) = MutableSlice::init(zones, i);
+        if z1.parent.is_some() {
+            continue;
+        }
+
+        let mut parents: Vec<_> = ztree
+            .fetch_zone_bbox(z1)
+            .into_iter()
+            .filter(|c_idx| c_idx.index != i)
+            .filter_map(|c_idx| {
+                let c = mslice.get(&c_idx);
+                if (c.admin_level < z1.admin_level) && c.contains(z1) {
+                    Some(c)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Temporary: we want to sort by admin_type
+        parents.sort_by_key(|p| p.admin_level.unwrap_or(0));
+        z1.set_parent(parents.last().map(|z| z.id.clone()));
+    }
+}
+
+// This struct is necessary to wrap the `zones` slice
+// and keep a mutable reference to a zone (and set
+// its parent) while still be able to borrow another
+// reference to another zone.
+struct MutableSlice<'a> {
+    pub right: &'a [Zone],
+    pub left: &'a [Zone],
+    pub idx: usize,
+}
+
+impl<'a> MutableSlice<'a> {
+    pub fn init(zones: &'a mut [Zone], index: usize) -> (Self, &'a mut Zone) {
+        let (left, temp) = zones.split_at_mut(index);
+        let (z, right) = temp.split_at_mut(1);
+        let s = Self {
+            right: right,
+            left: left,
+            idx: index,
+        };
+        (s, &mut z[0])
+    }
+
+    pub fn get(&self, zindex: &ZoneIndex) -> &Zone {
+        let idx = zindex.index;
+        if idx < self.idx {
+            return &self.left[idx];
+        } else if idx == self.idx {
+            panic!("Cannot retrieve middle index");
+        } else {
+            return &self.right[idx - self.idx - 1];
+        }
+    }
+}
+
+// the goal is that f in [down(f as f32) as f64, up(f as f32) as f64]
+fn down(f: f32) -> f32 {
+    f - (f * ::std::f32::EPSILON).abs()
+}
+fn up(f: f32) -> f32 {
+    f + (f * ::std::f32::EPSILON).abs()
+}
+
+#[cfg(test)]
+mod test {
+    use geo::{LineString, MultiPolygon, Point, Polygon};
+    use zone::{Zone, ZoneIndex};
+    use hierarchy_builder::build_hierarchy;
+    use osmpbfreader::Tags;
+
+    fn zone_factory(idx: usize, ls: LineString<f64>, admin_level: u32) -> Zone {
+        let p = Polygon::new(ls, vec![]);
+        let mp = MultiPolygon(vec![p.clone()]);
+
+        Zone {
+            id: ZoneIndex { index: idx },
+            osm_id: "".into(),
+            admin_level: Some(admin_level),
+            admin_type: None,
+            name: "".into(),
+            center: None,
+            boundary: Some(mp),
+            parent: None,
+            tags: Tags::new(),
+            wikidata: None,
+            zip_codes: vec![],
+        }
+    }
+
+    #[test]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn hierarchy_test() {
+        let l0 = LineString(vec![
+            Point::new(0., 0.),     //  +------+
+            Point::new(0., 10.),    //  |      |
+            Point::new(10., 10.),   //  |  z0  |
+            Point::new(10., 0.),    //  |      |
+            Point::new(0., 0.),     //  +------+
+        ]);
+        let z0 = zone_factory(0, l0, 2);
+
+        let l1 = LineString(vec![
+            Point::new(1., 1.),     //  +------+
+            Point::new(1., 9.),     //  |+----+|
+            Point::new(9., 9.),     //  || z1 ||
+            Point::new(9., 1.),     //  |+----+|
+            Point::new(1., 1.),     //  +------+
+        ]);
+        let z1 = zone_factory(1, l1, 5);
+
+        let l2 = LineString(vec![
+            Point::new(2., 2.),     //  +------+
+            Point::new(2., 8.),     //  |      |
+            Point::new(8., 8.),     //  |  []<---- z2
+            Point::new(8., 2.),     //  |      |
+            Point::new(2., 2.),     //  +------+
+        ]);
+        let z2 = zone_factory(2, l2, 6);
+
+        let l3 = LineString(vec![
+            Point::new(0., 0.),     //  +------+
+            Point::new(0., 5.),     //  |      |
+            Point::new(10., 5.),    //  +------+
+            Point::new(10., 0.),    //  |  z3  |
+            Point::new(0., 0.),     //  +------+
+        ]);
+        let z3 = zone_factory(3, l3, 3);
+
+        let mut zones = vec![z0, z1, z2, z3];
+
+        build_hierarchy(&mut zones);
+
+        fn assert_parent(zones: &[Zone], idx: usize, expected_parent: Option<usize>){
+            match (expected_parent, zones[idx].parent.clone()) {
+                (None, None) => (),
+                (Some(_), None) => panic!("Zone {} should have a parent", idx),
+                (None, Some(_)) => panic!("Zone {} should not have a parent", idx),
+                (Some(i), Some(zi)) => assert_eq!(i, zi.index)
+            }
+        }
+
+        assert_parent(&zones, 0, None);    // z0 has no parent
+        assert_parent(&zones, 1, Some(0)); // z1 parent is z0
+        assert_parent(&zones, 2, Some(1)); // z2 parent is z1
+        assert_parent(&zones, 3, Some(0)); // z3 parent is z0
+    }
+}

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -273,7 +273,7 @@ mod test {
     }
 
     #[test]
-    fn hierarchy_test_parent_parent_repect_hierarchy_equals() {
+    fn hierarchy_test_parent_parent_respect_hierarchy_equals() {
         let mut zones = create_zones();
 
         // now we change the zone type of z2 to a State,
@@ -290,7 +290,7 @@ mod test {
 
     /// A zone with a lower zone type should never be a parent to a zone with a higher zone type
     #[test]
-    fn hierarchy_test_parent_parent_repect_hierarchy() {
+    fn hierarchy_test_parent_parent_respect_hierarchy() {
         let mut zones = create_zones();
 
         // now we change the zone type of z2 to a CountryRegion,
@@ -308,7 +308,7 @@ mod test {
     /// a zone without a zone_type should not be a parent
     ///(but should be attached to an admin
     #[test]
-    fn hierarchy_test_parent_parent_repect_hierarchy_no_type() {
+    fn hierarchy_test_parent_parent_respect_hierarchy_no_type() {
         let mut zones = create_zones();
 
         // now we change the zone type of z1 to None, so it cannot be parent anymore

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -1,7 +1,7 @@
 extern crate geo;
 
 use std::iter::FromIterator;
-use zone::{Zone, ZoneIndex};
+use zone::{Zone, ZoneIndex, ZoneType};
 use gst::rtree::{RTree, Rect};
 use ordered_float::OrderedFloat;
 use geo::Bbox;
@@ -67,33 +67,76 @@ pub fn bbox_to_rect(bbox: Bbox<f64>) -> Rect {
     }
 }
 
+/// Function that tests if an Option<ZoneType> is smaller than other Option<ZoneType>
+/// the ordering depends on the postion in the enum, eg a City is smaller than a State
+fn is_smaller(a: Option<ZoneType>, b: Option<ZoneType>) -> bool {
+    match (a, b) {
+        (None, _) => false,
+        (_, None) => true,
+        (Some(a), Some(b)) => a < b,
+    }
+}
+
+impl Zone {
+    /// a zone can be a child of another zone z if:
+    /// z is an admin (we don't want to have non administrative zones as parent)
+    /// z's type is larger (so a State cannot have a City as parent)
+    fn can_be_linked_to(&self, z: &Zone) -> bool {
+        z.is_admin() && match self.zone_type {
+            Some(ZoneType::NonAdministrative) | None => true,
+            _ => is_smaller(self.zone_type, z.zone_type),
+        }
+    }
+}
+
+/// Build the cosmogony hierarchy for all the zones
+///
+/// The hierarchy is a tree.
+/// The zone parent is basically the 'smallest' admin that contains the zone
+///
+/// Some additional checks are done:
+/// * a zone can be attached only to an administrative zone
+/// * a zone must be attached to zone with a 'greater' zone_type
+///     a City cannot be attached to a CityDistrict or a Suburb, it should be attached to a
+///     StateDistrict, a State, a CountryRegion or a Country
 pub fn build_hierarchy(zones: &mut [Zone]) {
     let ztree: ZonesTree = zones.iter().collect();
     let nb_zones = zones.len();
 
     for i in 0..nb_zones {
-        let (mslice, z1) = MutableSlice::init(zones, i);
-        if z1.parent.is_some() {
+        let (mslice, z) = MutableSlice::init(zones, i);
+        if z.parent.is_some() {
             continue;
         }
 
-        let mut parents: Vec<_> = ztree
-            .fetch_zone_bbox(z1)
+        let parent = ztree
+            .fetch_zone_bbox(z)
             .into_iter()
             .filter(|c_idx| c_idx.index != i)
             .filter_map(|c_idx| {
                 let c = mslice.get(&c_idx);
-                if (c.admin_level < z1.admin_level) && c.contains(z1) {
+                if z.can_be_linked_to(c) {
                     Some(c)
                 } else {
                     None
                 }
             })
-            .collect();
+            .fold(None, |smallest, candidate| {
+                // we test first that the candidate's type is smaller that the smallest
+                // since the contains is not cheap and if we already found a State that
+                // contains `z` we can skip testing the country
+                if is_smaller(
+                    candidate.zone_type,
+                    smallest.and_then(|s: &Zone| s.zone_type),
+                ) && candidate.contains(z)
+                {
+                    Some(candidate)
+                } else {
+                    smallest
+                }
+            });
 
-        // Temporary: we want to sort by admin_type
-        parents.sort_by_key(|p| p.admin_level.unwrap_or(0));
-        z1.set_parent(parents.last().map(|z| z.id.clone()));
+        z.set_parent(parent.map(|z| z.id.clone()));
     }
 }
 
@@ -142,19 +185,19 @@ fn up(f: f32) -> f32 {
 #[cfg(test)]
 mod test {
     use geo::{LineString, MultiPolygon, Point, Polygon};
-    use zone::{Zone, ZoneIndex};
+    use zone::{Zone, ZoneIndex, ZoneType};
     use hierarchy_builder::build_hierarchy;
     use osmpbfreader::Tags;
 
-    fn zone_factory(idx: usize, ls: LineString<f64>, admin_level: u32) -> Zone {
+    fn zone_factory(idx: usize, ls: LineString<f64>, zone_type: Option<ZoneType>) -> Zone {
         let p = Polygon::new(ls, vec![]);
         let mp = MultiPolygon(vec![p.clone()]);
 
         Zone {
             id: ZoneIndex { index: idx },
             osm_id: "".into(),
-            admin_level: Some(admin_level),
-            admin_type: None,
+            admin_level: None,
+            zone_type: zone_type,
             name: "".into(),
             center: None,
             boundary: Some(mp),
@@ -166,16 +209,40 @@ mod test {
     }
 
     #[test]
+    fn test_is_smaller_simple() {
+        let smallest = Some(ZoneType::City);
+        let candidate = Some(ZoneType::Country);
+        assert_eq!(super::is_smaller(smallest, candidate), true);
+    }
+    #[test]
+    fn test_is_smaller_first_none() {
+        let smallest = None;
+        let candidate = Some(ZoneType::Country);
+        assert_eq!(super::is_smaller(smallest, candidate), false);
+    }
+    #[test]
+    fn test_is_smaller_second_none() {
+        let smallest = Some(ZoneType::City);
+        let candidate = None;
+        assert_eq!(super::is_smaller(smallest, candidate), true);
+    }
+    #[test]
+    fn test_is_smaller_equal() {
+        let smallest = Some(ZoneType::City);
+        let candidate = Some(ZoneType::City);
+        assert_eq!(super::is_smaller(smallest, candidate), false);
+    }
+
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    fn hierarchy_test() {
-        let l0 = LineString(vec![
+    fn create_zones() -> Vec<Zone> {
+                let l0 = LineString(vec![
             Point::new(0., 0.),     //  +------+
             Point::new(0., 10.),    //  |      |
             Point::new(10., 10.),   //  |  z0  |
             Point::new(10., 0.),    //  |      |
             Point::new(0., 0.),     //  +------+
         ]);
-        let z0 = zone_factory(0, l0, 2);
+        let z0 = zone_factory(0, l0, Some(ZoneType::Country));
 
         let l1 = LineString(vec![
             Point::new(1., 1.),     //  +------+
@@ -184,7 +251,7 @@ mod test {
             Point::new(9., 1.),     //  |+----+|
             Point::new(1., 1.),     //  +------+
         ]);
-        let z1 = zone_factory(1, l1, 5);
+        let z1 = zone_factory(1, l1, Some(ZoneType::State));
 
         let l2 = LineString(vec![
             Point::new(2., 2.),     //  +------+
@@ -193,7 +260,7 @@ mod test {
             Point::new(8., 2.),     //  |      |
             Point::new(2., 2.),     //  +------+
         ]);
-        let z2 = zone_factory(2, l2, 6);
+        let z2 = zone_factory(2, l2, Some(ZoneType::City));
 
         let l3 = LineString(vec![
             Point::new(0., 0.),     //  +------+
@@ -202,24 +269,95 @@ mod test {
             Point::new(10., 0.),    //  |  z3  |
             Point::new(0., 0.),     //  +------+
         ]);
-        let z3 = zone_factory(3, l3, 3);
+        let z3 = zone_factory(3, l3, Some(ZoneType::State));
 
-        let mut zones = vec![z0, z1, z2, z3];
+        vec![z0, z1, z2, z3]
+    }
+
+    fn assert_parent(zones: &[Zone], idx: usize, expected_parent: Option<usize>) {
+        match (expected_parent, zones[idx].parent.clone()) {
+            (None, None) => (),
+            (Some(_), None) => panic!("Zone {} should have a parent", idx),
+            (None, Some(_)) => panic!("Zone {} should not have a parent", idx),
+            (Some(i), Some(zi)) => assert_eq!(i, zi.index),
+        }
+    }
+
+    #[test]
+    fn hierarchy_test() {
+        let mut zones = create_zones();
 
         build_hierarchy(&mut zones);
 
-        fn assert_parent(zones: &[Zone], idx: usize, expected_parent: Option<usize>){
-            match (expected_parent, zones[idx].parent.clone()) {
-                (None, None) => (),
-                (Some(_), None) => panic!("Zone {} should have a parent", idx),
-                (None, Some(_)) => panic!("Zone {} should not have a parent", idx),
-                (Some(i), Some(zi)) => assert_eq!(i, zi.index)
-            }
-        }
-
-        assert_parent(&zones, 0, None);    // z0 has no parent
+        assert_parent(&zones, 0, None); // z0 has no parent
         assert_parent(&zones, 1, Some(0)); // z1 parent is z0
         assert_parent(&zones, 2, Some(1)); // z2 parent is z1
+        assert_parent(&zones, 3, Some(0)); // z3 parent is z0
+    }
+
+    #[test]
+    fn hierarchy_test_parent_only_admin() {
+        let mut zones = create_zones();
+
+        // now we change the zone type of z1 to a non administrative region,
+        // it should not be a parent anymore
+        zones[1].zone_type = Some(ZoneType::NonAdministrative);
+
+        build_hierarchy(&mut zones);
+
+        assert_parent(&zones, 0, None); // z0 has no parent
+        assert_parent(&zones, 1, Some(0)); // z1 parent is z0
+        assert_parent(&zones, 2, Some(0)); // z2 parent is z0
+        assert_parent(&zones, 3, Some(0)); // z3 parent is z0
+    }
+
+    #[test]
+    fn hierarchy_test_parent_parent_repect_hierarchy_equals() {
+        let mut zones = create_zones();
+
+        // now we change the zone type of z2 to a State,
+        // so it cannot have a state has parent anymore
+        zones[2].zone_type = Some(ZoneType::State);
+
+        build_hierarchy(&mut zones);
+
+        assert_parent(&zones, 0, None); // z0 has no parent
+        assert_parent(&zones, 1, Some(0)); // z1 parent is z0
+        assert_parent(&zones, 2, Some(0)); // z2 parent is z0 even if it is contained by z1
+        assert_parent(&zones, 3, Some(0)); // z3 parent is z0
+    }
+
+    /// A zone with a lower zone type should never be a parent to a zone with a higher zone type
+    #[test]
+    fn hierarchy_test_parent_parent_repect_hierarchy() {
+        let mut zones = create_zones();
+
+        // now we change the zone type of z2 to a CountryRegion,
+        // so it cannot have a state has parent anymore
+        zones[2].zone_type = Some(ZoneType::CountryRegion);
+
+        build_hierarchy(&mut zones);
+
+        assert_parent(&zones, 0, None); // z0 has no parent
+        assert_parent(&zones, 1, Some(0)); // z1 parent is z0
+        assert_parent(&zones, 2, Some(0)); // z2 parent is z0 even if it is contained by z1
+        assert_parent(&zones, 3, Some(0)); // z3 parent is z0
+    }
+
+    /// a zone without a zone_type should not be a parent
+    ///(but should be attached to an admin
+    #[test]
+    fn hierarchy_test_parent_parent_repect_hierarchy_no_type() {
+        let mut zones = create_zones();
+
+        // now we change the zone type of z1 to None, so it cannot be parent anymore
+        zones[1].zone_type = None;
+
+        build_hierarchy(&mut zones);
+
+        assert_parent(&zones, 0, None); // z0 has no parent
+        assert_parent(&zones, 1, Some(0)); // z1 parent is z0
+        assert_parent(&zones, 2, Some(0)); // z2 parent is z0 even if it is contained by z1
         assert_parent(&zones, 3, Some(0)); // z3 parent is z0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,18 +14,14 @@ extern crate structopt;
 
 pub mod zone;
 mod hierarchy_builder;
-pub mod admin_type;
 pub mod cosmogony;
 pub mod zone_typer;
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use cosmogony::{AdminRules, Cosmogony, CosmogonyMetadata, CosmogonyStats};
+use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
 use osmpbfreader::{OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
-use std::fs;
-use std::io::prelude::*;
-use std::io;
 use hierarchy_builder::build_hierarchy;
 use failure::Error;
 use failure::ResultExt;
@@ -73,7 +69,6 @@ pub fn get_zones_and_stats(
         }
     }
 
-    build_hierarchy(&mut zones);
     return Ok((zones, stats));
 }
 
@@ -110,7 +105,7 @@ fn get_country<'a>(_zone: &zone::Zone, country_code: &'a Option<String>) -> Resu
     }
 }
 
-fn create_ontology(
+fn type_zones(
     zones: &mut Vec<zone::Zone>,
     stats: &mut CosmogonyStats,
     libpostal_file_path: PathBuf,
@@ -138,6 +133,18 @@ fn create_ontology(
             }
         }
     }
+    Ok(())
+}
+
+fn create_ontology(
+    zones: &mut Vec<zone::Zone>,
+    stats: &mut CosmogonyStats,
+    libpostal_file_path: PathBuf,
+    country_code: Option<String>,
+) -> Result<(), Error> {
+    type_zones(zones, stats, libpostal_file_path, country_code)?;
+
+    build_hierarchy(zones);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 #[macro_use]
 extern crate failure;
+extern crate geo;
+extern crate gst;
 #[macro_use]
 extern crate log;
 extern crate mimirsbrunn;
+extern crate ordered_float;
 extern crate osmpbfreader;
 #[macro_use]
 extern crate serde_derive;
@@ -10,16 +13,23 @@ extern crate serde_yaml;
 extern crate structopt;
 
 pub mod zone;
+mod hierarchy_builder;
+pub mod admin_type;
 pub mod cosmogony;
 pub mod zone_typer;
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
+use cosmogony::{AdminRules, Cosmogony, CosmogonyMetadata, CosmogonyStats};
 use osmpbfreader::{OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
+use std::fs;
+use std::io::prelude::*;
+use std::io;
+use hierarchy_builder::build_hierarchy;
 use failure::Error;
 use failure::ResultExt;
+use zone::ZoneIndex;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn is_admin(obj: &OsmObj) -> bool {
@@ -51,16 +61,19 @@ pub fn get_zones_and_stats(
             continue;
         }
         if let OsmObj::Relation(ref relation) = *obj {
-            if let Some(zone) = zone::Zone::from_osm_with_geom(relation, &objects) {
+            let next_index = ZoneIndex { index: zones.len() };
+            if let Some(zone) = zone::Zone::from_osm_with_geom(relation, &objects, next_index) {
                 // Ignore zone without boundary polygon
+
                 if zone.boundary.is_some() {
                     stats.process(&zone);
                     zones.push(zone);
                 }
-            }
+            };
         }
     }
 
+    build_hierarchy(&mut zones);
     return Ok((zones, stats));
 }
 
@@ -77,7 +90,8 @@ pub fn get_zones_and_stats_without_geom(
             continue;
         }
         if let OsmObj::Relation(ref relation) = obj {
-            if let Some(zone) = zone::Zone::from_osm(relation) {
+            let next_index = ZoneIndex { index: zones.len() };
+            if let Some(zone) = zone::Zone::from_osm(relation, next_index) {
                 stats.process(&zone);
                 zones.push(zone);
             }

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use self::geos::GGeom;
 use self::serde::Serialize;
 
-#[derive(Serialize, Deserialize, Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Copy, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum ZoneType {
     Suburb,

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -1,16 +1,18 @@
 extern crate geo;
 extern crate geojson;
+extern crate geos;
 extern crate itertools;
 extern crate mimir;
 extern crate mimirsbrunn;
 extern crate serde;
 
-use std::rc::Rc;
 use self::itertools::Itertools;
-use self::mimir::{Coord, Property};
-use osmpbfreader::objects::{OsmId, OsmObj, Relation};
+use self::mimir::Coord;
+use osmpbfreader::objects::{OsmId, OsmObj, Relation, Tags};
 use self::mimirsbrunn::boundaries::{build_boundary, make_centroid};
 use std::collections::BTreeMap;
+use self::geos::GGeom;
+use self::serde::Serialize;
 
 #[derive(Serialize, Deserialize, Copy, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -25,9 +27,15 @@ pub enum ZoneType {
     NonAdministrative,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+pub struct ZoneIndex {
+    pub index: usize,
+}
+
+#[derive(Serialize, Debug, Clone)]
 pub struct Zone {
-    pub id: String,
+    pub id: ZoneIndex,
+    pub osm_id: String,
     pub admin_level: Option<u32>,
     pub zone_type: Option<ZoneType>,
     pub name: String,
@@ -36,10 +44,13 @@ pub struct Zone {
     #[serde(serialize_with = "serialize_as_geojson", deserialize_with = "deserialize_as_geojson",
             rename = "geometry", default)]
     pub boundary: Option<geo::MultiPolygon<f64>>,
-    pub parent: Option<Rc<Zone>>,
-    pub tags: Vec<Property>,
+
+    #[serde(skip_serializing)]
+    pub tags: Tags,
+
+    pub parent: Option<ZoneIndex>,
     pub wikidata: Option<String>,
-    // pub links: Vec<Rc<Zone>>
+    // pub links: Vec<ZoneIndex>
 }
 
 impl Zone {
@@ -51,7 +62,11 @@ impl Zone {
         }
     }
 
-    pub fn from_osm(relation: &Relation) -> Option<Self> {
+    pub fn set_parent(&mut self, idx: Option<ZoneIndex>) {
+        self.parent = idx;
+    }
+
+    pub fn from_osm(relation: &Relation, index: ZoneIndex) -> Option<Self> {
         // Skip administrative region without name
         let name = match relation.tags.get("name") {
             Some(val) => val,
@@ -81,7 +96,8 @@ impl Zone {
         let wikidata = relation.tags.get("wikidata").map(|s| s.to_string());
 
         Some(Self {
-            id: relation.id.0.to_string(),
+            id: index,
+            osm_id: relation.id.0.to_string(),
             admin_level: level,
             zone_type: None,
             name: name.to_string(),
@@ -89,7 +105,7 @@ impl Zone {
             center: None,
             boundary: None,
             parent: None,
-            tags: vec![],
+            tags: relation.tags.clone(),
             wikidata: wikidata,
         })
     }
@@ -97,8 +113,9 @@ impl Zone {
     pub fn from_osm_with_geom(
         relation: &Relation,
         objects: &BTreeMap<OsmId, OsmObj>,
+        index: ZoneIndex,
     ) -> Option<Self> {
-        Self::from_osm(relation).map(|mut result| {
+        Self::from_osm(relation, index).map(|mut result| {
             result.boundary = build_boundary(relation, objects);
 
             result.center = Some(
@@ -115,6 +132,20 @@ impl Zone {
 
             result
         })
+    }
+
+    pub fn contains(&self, other: &Zone) -> bool {
+        return match (&self.boundary, &other.boundary) {
+            (&Some(ref mpoly1), &Some(ref mpoly2)) => {
+                let m_self: GGeom = mpoly1.into();
+                let m_other: GGeom = mpoly2.into();
+
+                // In GEOS, "covers" is less strict than "contains".
+                // eg: a polygon does NOT "contain" its boundary, but "covers" it.
+                m_self.covers(&m_other)
+            }
+            _ => false,
+        };
     }
 }
 
@@ -162,4 +193,13 @@ where
             _ => None,
         })
     })
+}
+
+impl Serialize for ZoneIndex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.index as u64)
+    }
 }


### PR DESCRIPTION
This defines a new function `build_hierarchy`.  
Zones are first inserted into a RTree, to look efficiently for potential parents.

In this version, the parent is required to have a lower `admin_level` ; we are not using `admin_type` yet. The parent is represented in each `Zone` object as a new `ZoneIndex` struct, and is serialized as an integer in [0, nb_zones).

Note that the  `contains` method is defined using [a custom GEOS binding](https://github.com/amatissart/rust-geos), that might be unstable at this stage.

