### PR TITLE
Add cosmogony deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.1.0 (git+https://github.com/QwantResearch/osm_boundaries_utils_rs)",
- "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.11.1 (git+https://github.com/antoine-de/osmpbfreader-rs?branch=flat_map_serialiaze)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,8 +161,12 @@ dependencies = [
 
 [[package]]
 name = "flat_map"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.0.7"
+source = "git+https://github.com/antoine-de/flat_map?branch=serialization#80e71bcf543bb754c98d82077e2b13f4a24d4359"
+dependencies = [
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "flate2"
@@ -394,20 +398,23 @@ source = "git+https://github.com/QwantResearch/osm_boundaries_utils_rs#3eb9155d0
 dependencies = [
  "geo 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.11.1 (git+https://github.com/antoine-de/osmpbfreader-rs?branch=flat_map_serialiaze)",
 ]
 
 [[package]]
 name = "osmpbfreader"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/antoine-de/osmpbfreader-rs?branch=flat_map_serialiaze#b52dad53224bdcbfb4c217e030f907b2bdfcdd5c"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flat_map 0.0.7 (git+https://github.com/antoine-de/flat_map?branch=serialization)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pub-iterator-type 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rental 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -740,7 +747,7 @@ dependencies = [
 "checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
-"checksum flat_map 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fc16c081affe2ded9d62cd239a9ef1b4801fa98037b59523014f661c7bee182c"
+"checksum flat_map 0.0.7 (git+https://github.com/antoine-de/flat_map?branch=serialization)" = "<none>"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -770,7 +777,7 @@ dependencies = [
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e312d9bf410688e9c292d9e7da4567143c0ad18df8fceb6ce99156f40cef2"
 "checksum osm_boundaries_utils 0.1.0 (git+https://github.com/QwantResearch/osm_boundaries_utils_rs)" = "<none>"
-"checksum osmpbfreader 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee6ac019a0e2e42e3a982dad2205b7ea61a65592ceecc4b565f405e824864962"
+"checksum osmpbfreader 0.11.1 (git+https://github.com/antoine-de/osmpbfreader-rs?branch=flat_map_serialiaze)" = "<none>"
 "checksum par-map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a148044b62c5002054d4a164b352cf1439fffed060073703e08ba0863d56fdaf"
 "checksum procedural-masquerade 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1bcafee1590f81acb329ae45ec627b318123f085153913620316ae9a144b2a"
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ gst = "0.1.3"
 ordered-float = "0.0.2"
 geos = { git = "https://github.com/amatissart/rust-geos.git" }
 osm_boundaries_utils = { git = "https://github.com/QwantResearch/osm_boundaries_utils_rs", version = "0.1" }
+
+[patch.crates-io]
+osmpbfreader = { git = "https://github.com/antoine-de/osmpbfreader-rs", branch = "flat_map_serialiaze" }

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use zone::Zone;
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Cosmogony {
     pub zones: Vec<Zone>,
     pub meta: CosmogonyMetadata,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,15 @@ pub mod zone_typer;
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
+pub use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
 use osmpbfreader::{OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
 use hierarchy_builder::build_hierarchy;
 use failure::Error;
 use failure::ResultExt;
-use zone::ZoneIndex;
 use country_finder::CountryFinder;
+
+pub use zone::{Zone, ZoneType, ZoneIndex};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn is_admin(obj: &OsmObj) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use failure::Error;
 use failure::ResultExt;
 use country_finder::CountryFinder;
 
-pub use zone::{Zone, ZoneType, ZoneIndex};
+pub use zone::{Zone, ZoneIndex, ZoneType};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn is_admin(obj: &OsmObj) -> bool {

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -10,7 +10,6 @@ use osm_boundaries_utils::build_boundary;
 use std::collections::BTreeMap;
 use self::geos::GGeom;
 use self::serde::Serialize;
-use self::serde;
 use std::fmt;
 use geo::Point;
 

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -1,13 +1,10 @@
 extern crate cosmogony;
+extern crate serde_json;
+use cosmogony::Cosmogony;
 
 use std::collections::BTreeMap;
 
-#[test]
-fn read_lux_admin_levels() {
-    // Ensure that all well-defined (with closed boundaries)
-    // administrative zones are loaded from the sample .osm.pbf file,
-    // with correct counts per admin_level.
-
+fn create_cosmogony_for_lux() -> Cosmogony {
     let test_file = concat!(
         env!("OUT_DIR"),
         "/../../../../../tests/data/luxembourg_filtered.osm.pbf"
@@ -18,10 +15,29 @@ fn read_lux_admin_levels() {
         "./libpostal/resources/boundaries/osm".into(),
         Some("lu".into()),
     ).expect("invalid cosmogony");
-    assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
+    return cosmogony;
+}
 
-    let level_counts = cosmogony.meta.stats.level_counts;
-    let wikidata_counts = cosmogony.meta.stats.wikidata_counts;
+#[test]
+fn test_lux_cosmogony() {
+    // Check some random values in the built cosmogony
+    // from the sample .osm.pbf file,
+    let cosmogony = create_cosmogony_for_lux();
+    assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
+    assert_eq!(cosmogony.zones.len(), 201);
+
+    assert!(
+        cosmogony
+            .zones
+            .iter()
+            .map(|zone| zone.name.to_owned())
+            .any(|name| name == format!("Esch-sur-Alzette"))
+    );
+}
+
+fn test_wrapper_for_lux_admin_levels(a_cosmogony: Cosmogony) {
+    let level_counts = a_cosmogony.meta.stats.level_counts;
+    let wikidata_counts = a_cosmogony.meta.stats.wikidata_counts;
 
     fn assert_count(counts: &BTreeMap<u32, u64>, key: u32, value: u64) {
         assert_eq!(
@@ -49,14 +65,25 @@ fn read_lux_admin_levels() {
     assert_count(&wikidata_counts, 8, 105);
     assert_count(&level_counts, 9, 79);
     assert_count(&level_counts, 10, 3); // 2 + 1 outside LU
+}
 
-    assert_eq!(cosmogony.zones.len(), 201);
+#[test]
+fn test_lux_admin_levels() {
+    // Ensure that all well-defined (with closed boundaries)
+    // administrative zones are loaded from the sample .osm.pbf file,
+    // with correct counts per admin_level.
+    let cosmogony = create_cosmogony_for_lux();
+    test_wrapper_for_lux_admin_levels(cosmogony);
+}
 
-    assert!(
-        cosmogony
-            .zones
-            .iter()
-            .map(|zone| zone.name.to_owned())
-            .any(|name| name == format!("Esch-sur-Alzette"))
-    )
+#[test]
+fn test_lux_admin_levels_with_serialisation() {
+    // Serialize and deserialize a built cosmogony
+    // and check again the admin_level counts.
+    let cosmogony = create_cosmogony_for_lux();
+
+    let cosmogony_as_json = serde_json::to_string(&cosmogony).unwrap();
+    let cosmogony_from_json: Cosmogony = serde_json::from_str(&cosmogony_as_json).unwrap();
+
+    test_wrapper_for_lux_admin_levels(cosmogony_from_json);
 }


### PR DESCRIPTION
the deserialization is needed by mimir to load a cosmogony.json

also reexport the main types for ergonomics.

In this Pr we override osmpbfreadeer because it needs https://github.com/TeXitoi/osmpbfreader-rs/pull/13