### PR TITLE
 read libpostal overrides

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libpostal"]
 	path = libpostal
-	url = https://github.com/openvenues/libpostal.git
+	url = https://github.com/osm-without-borders/libpostal.git

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -280,4 +280,20 @@ mod test {
             &None
         );
     }
+
+    /// test reading all the libpostal files
+    #[test]
+    fn test_read_all_libpostal_files() {
+        use std::io::Read;
+        let libpostal_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/libpostal/resources/boundaries/osm/");
+
+        for f in fs::read_dir(&libpostal_dir).unwrap() {
+            let a_path = f.unwrap();
+            let mut f = fs::File::open(&a_path.path()).unwrap();
+            let mut contents = String::new();
+            f.read_to_string(&mut contents).map_err(|e| warn!("impossible to read file {:?} because {}", a_path, e)).unwrap();
+            // there should be no error while reading a file
+            read_libpostal_yaml(&contents).unwrap();
+        }
+    }
 }

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -14,7 +14,7 @@ pub struct ZoneTyper {
 }
 
 #[derive(Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug)]
-enum OsmPrimaryObects {
+enum OsmPrimaryObjects {
     #[serde(rename = "node")]
     Node,
     #[serde(rename = "way")]
@@ -26,9 +26,9 @@ enum OsmPrimaryObects {
 #[derive(Serialize, Deserialize, Default, Debug)]
 struct RulesOverrides {
     #[serde(default)]
-    contained_by: BTreeMap<OsmPrimaryObects, BTreeMap<String, CountryAdminTypeRules>>,
+    contained_by: BTreeMap<OsmPrimaryObjects, BTreeMap<String, CountryAdminTypeRules>>,
     #[serde(rename = "id", default)]
-    id_rules: BTreeMap<OsmPrimaryObects, BTreeMap<String, Option<ZoneType>>>,
+    id_rules: BTreeMap<OsmPrimaryObjects, BTreeMap<String, Option<ZoneType>>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -141,7 +141,7 @@ fn read_libpostal_yaml(contents: &str) -> Result<CountryAdminTypeRules, Error> {
 mod test {
     use zone::ZoneType;
     use zone_typer::read_libpostal_yaml;
-    use super::OsmPrimaryObects;
+    use super::OsmPrimaryObjects;
     use std::fs;
 
     #[test]
@@ -226,7 +226,7 @@ mod test {
             deserialized_levels
                 .overrides
                 .contained_by
-                .get(&OsmPrimaryObects::Relation).unwrap()
+                .get(&OsmPrimaryObjects::Relation).unwrap()
                 .get(&"407489".to_string()).unwrap()
                 .type_by_level
                 .get(&"9".to_string())
@@ -266,7 +266,7 @@ mod test {
             deserialized_levels
                 .overrides
                 .id_rules
-                .get(&OsmPrimaryObects::Relation).unwrap()
+                .get(&OsmPrimaryObjects::Relation).unwrap()
                 .get(&"1803923".to_string()).unwrap(),
             &Some(ZoneType::CityDistrict)
         );
@@ -275,7 +275,7 @@ mod test {
             deserialized_levels
                 .overrides
                 .id_rules
-                .get(&OsmPrimaryObects::Relation).unwrap()
+                .get(&OsmPrimaryObjects::Relation).unwrap()
                 .get(&"42".to_string()).unwrap(),
             &None
         );


### PR DESCRIPTION
read `contained_by` and `id` libpostal's overrides (but does not yet implement the uses of those overrides, that will be for another PR.

also update libpostal's submodule to use our own fork with some correction in the yaml files (we'll be able to return to the main libpostal repository once https://github.com/openvenues/libpostal/pull/348 is merged and we have done a PR like https://github.com/osm-without-borders/libpostal/pull/1)