### PR TITLE
implement libpostal overrides

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate log;
 extern crate ordered_float;
 extern crate osm_boundaries_utils;
 extern crate osmpbfreader;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate regex;

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::fs;
 use std::io::prelude::*;
 use std::path::Path;
-use zone::{Zone, ZoneType};
+use zone::{Zone, ZoneIndex, ZoneType};
 
 #[derive(Debug)]
 pub struct ZoneTyper {
@@ -20,7 +20,7 @@ enum OsmPrimaryObjects {
     #[serde(rename = "way")]
     Way,
     #[serde(rename = "relation")]
-    Relation
+    Relation,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -71,18 +71,74 @@ impl ZoneTyper {
         &self,
         zone: &Zone,
         country_code: &str,
+        zone_inclusions: &Vec<ZoneIndex>,
+        all_zones: &[Zone],
     ) -> Result<ZoneType, ZoneTyperError> {
         let country_rules = self.countries_rules
             .get(&country_code.to_lowercase()) // file postal code are lowercase
             .ok_or(ZoneTyperError::InvalidCountry(country_code.to_string()))?;
         Ok(country_rules
-            .type_by_level
-            .get(&zone.admin_level.unwrap_or(0).to_string())
+            .get_zone_type(zone, zone_inclusions, all_zones)
             .ok_or(ZoneTyperError::UnkownLevel(
                 zone.admin_level.clone(),
                 country_code.to_string(),
             ))?
             .clone())
+    }
+}
+
+impl CountryAdminTypeRules {
+    /// Find the type of a zone using libpostal's rules
+    ///
+    /// First we look if there is a specific rule for the zone,
+    /// else we take the default osm's admin_level rule
+    fn get_zone_type(
+        &self,
+        zone: &Zone,
+        zone_inclusions: &Vec<ZoneIndex>,
+        all_zones: &[Zone],
+    ) -> Option<ZoneType> {
+        let overrides = self.overrides
+            .get_overrided_type(zone, zone_inclusions, all_zones);
+        match overrides {
+            Some(o) => o,
+            None => self.type_by_level
+                .get(&zone.admin_level.unwrap_or(0).to_string())
+                .cloned(),
+        }
+    }
+}
+
+impl RulesOverrides {
+    /// find the overrided type if it exists
+    ///
+    /// This returns an Option<Option<ZoneType>>:
+    /// Some(val) => if we have a specific rule for the zone (and val can be None, this is a way for libpostal to explicitly not type some zones)
+    /// None => We have no specific rule for the zone
+    fn get_overrided_type(
+        &self,
+        zone: &Zone,
+        zone_inclusions: &Vec<ZoneIndex>,
+        all_zones: &[Zone],
+    ) -> Option<Option<ZoneType>> {
+        // check id overrides
+        let id_overrides = self.id_rules
+        .get(&OsmPrimaryObjects::Relation) // for the moment we only have relations
+        .and_then(|m| m.get(&zone.osm_id));
+        // if there is no override for this specific object, we check the contained_by overrides
+        match id_overrides {
+            Some(overrides) => Some(overrides.clone()),
+            None => self.contained_by
+        .get(&OsmPrimaryObjects::Relation) // still only relations
+        .and_then(|relations_rules| {
+            let parents_osm_id: Vec<_> = zone_inclusions.iter().map(|idx| &all_zones[idx.index].osm_id).collect();
+
+            relations_rules
+            .iter()
+            .find(|&(ref osm_id, _)| parents_osm_id.contains(osm_id))
+            .and_then(|(_, ref country_rules)| country_rules.get_zone_type(zone, zone_inclusions, all_zones).map(|r| Some(r)))
+        }),
+        }
     }
 }
 
@@ -139,10 +195,10 @@ fn read_libpostal_yaml(contents: &str) -> Result<CountryAdminTypeRules, Error> {
 
 #[cfg(test)]
 mod test {
-    use zone::ZoneType;
-    use zone_typer::read_libpostal_yaml;
-    use super::OsmPrimaryObjects;
+    use super::{CountryAdminTypeRules, OsmPrimaryObjects};
     use std::fs;
+    use zone::{Zone, ZoneIndex, ZoneType};
+    use zone_typer::read_libpostal_yaml;
 
     #[test]
     fn test_read_libpostal_yaml_basic() {
@@ -226,8 +282,10 @@ mod test {
             deserialized_levels
                 .overrides
                 .contained_by
-                .get(&OsmPrimaryObjects::Relation).unwrap()
-                .get(&"407489".to_string()).unwrap()
+                .get(&OsmPrimaryObjects::Relation)
+                .unwrap()
+                .get(&"407489".to_string())
+                .unwrap()
                 .type_by_level
                 .get(&"9".to_string())
                 .unwrap(),
@@ -266,8 +324,10 @@ mod test {
             deserialized_levels
                 .overrides
                 .id_rules
-                .get(&OsmPrimaryObjects::Relation).unwrap()
-                .get(&"1803923".to_string()).unwrap(),
+                .get(&OsmPrimaryObjects::Relation)
+                .unwrap()
+                .get(&"1803923".to_string())
+                .unwrap(),
             &Some(ZoneType::CityDistrict)
         );
 
@@ -275,8 +335,10 @@ mod test {
             deserialized_levels
                 .overrides
                 .id_rules
-                .get(&OsmPrimaryObjects::Relation).unwrap()
-                .get(&"42".to_string()).unwrap(),
+                .get(&OsmPrimaryObjects::Relation)
+                .unwrap()
+                .get(&"42".to_string())
+                .unwrap(),
             &None
         );
     }
@@ -285,15 +347,128 @@ mod test {
     #[test]
     fn test_read_all_libpostal_files() {
         use std::io::Read;
-        let libpostal_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/libpostal/resources/boundaries/osm/");
+        let libpostal_dir = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/libpostal/resources/boundaries/osm/"
+        );
 
         for f in fs::read_dir(&libpostal_dir).unwrap() {
             let a_path = f.unwrap();
             let mut f = fs::File::open(&a_path.path()).unwrap();
             let mut contents = String::new();
-            f.read_to_string(&mut contents).map_err(|e| warn!("impossible to read file {:?} because {}", a_path, e)).unwrap();
+            f.read_to_string(&mut contents)
+                .map_err(|e| warn!("impossible to read file {:?} because {}", a_path, e))
+                .unwrap();
             // there should be no error while reading a file
             read_libpostal_yaml(&contents).unwrap();
         }
+    }
+
+    /// helper method to return a yaml with many corner cases
+    fn complex_rules() -> CountryAdminTypeRules {
+        let yaml = r#"---
+    admin_level:
+        "2": "country"
+        "4": "state"
+        "5": "state_district"
+        "6": "state_district"
+        "8": "city"
+        "9": "suburb"
+
+    overrides:
+        id:
+            relation:
+                "z1": "city_district"
+                "z4": null # it is a way in libpostal to remove a zone from being typed
+                "z5": "city_district"
+
+        contained_by:
+            relation:
+                "big_zone":
+                    admin_level:
+                        "9": "suburb"
+                "#;
+        read_libpostal_yaml(&yaml).expect("invalid yaml")
+    }
+
+    #[test]
+    fn simple_get_zone_type_test() {
+        let rules = complex_rules();
+
+        let mut idx = 0usize;
+        let mut make_zone = |id: &str, lvl| {
+            let mut z = Zone::default();
+            z.id = ZoneIndex { index: idx };
+            idx += 1;
+            z.osm_id = id.to_string();
+            z.admin_level = lvl;
+            z
+        };
+        let zones = vec![
+            make_zone("z1", None),
+            make_zone("z2", Some(5)),
+            make_zone("z3", Some(9)),
+            make_zone("z4", Some(9)),
+            make_zone("z5", Some(7)),
+            make_zone("z6", Some(7)),
+            make_zone("big_zone", Some(4)),
+            make_zone("very_big_zone", Some(2)),
+        ];
+
+        let mut inclusions = vec![vec![]; zones.len()];
+        {
+            let mut included_by = |z_osm_id, parents_id: Vec<&str>| {
+                let find_zone_id = |osm_id: &str| {
+                    zones
+                        .iter()
+                        .find(|z| z.osm_id == osm_id.to_string())
+                        .unwrap()
+                        .id
+                        .clone()
+                };
+                inclusions[find_zone_id(z_osm_id).index] =
+                    parents_id.into_iter().map(&find_zone_id).collect();
+            };
+            included_by("z1", vec!["big_zone"]);
+            included_by("z2", vec!["big_zone"]);
+            included_by("z3", vec!["very_big_zone", "big_zone"]);
+            included_by("z4", vec!["big_zone"]);
+            included_by("z5", vec![]);
+            included_by("z6", vec![]);
+            included_by("big_zone", vec![]);
+            included_by("very_big_zone", vec![]);
+        }
+
+        let get_zone_type = |osm_id: &str| {
+            let z = zones
+                .iter()
+                .find(|z| z.osm_id == osm_id.to_string())
+                .unwrap();
+            rules.get_zone_type(&z, &inclusions[z.id.index], &zones)
+        };
+
+        // even if z1 has no admin_level it has explicitly been set by libpostal to city_district
+        assert_eq!(get_zone_type("z1"), Some(ZoneType::CityDistrict));
+
+        // z2 is contained by 'big_zone' that has some overrides, but they do not concerns z2, so the default apply (5 -> StateDistrict)
+        assert_eq!(get_zone_type("z2"), Some(ZoneType::StateDistrict));
+
+        // z3 is contained by 'big_zone' that has a special rule for the admin_level 9
+        assert_eq!(get_zone_type("z3"), Some(ZoneType::Suburb));
+
+        // z4 has 2 conflicting override rules that can be applied:
+        // contained by 'big_zone' and explicit Id override
+        // in this case it's the 'id rule' that wins
+        assert_eq!(get_zone_type("z4"), None);
+
+        // z5 has a simple override by id
+        assert_eq!(get_zone_type("z5"), Some(ZoneType::CityDistrict));
+
+        // z6 has no override, but it's level is not mapped
+        assert_eq!(get_zone_type("z6"), None);
+
+        // no specific stuff for big_zone and very_big zone
+        assert_eq!(get_zone_type("big_zone"), Some(ZoneType::State));
+        assert_eq!(get_zone_type("very_big_zone"), Some(ZoneType::Country));
     }
 }

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -151,7 +151,7 @@ fn test_lux_zone_types() {
             key
         )
     }
-    assert_count(&zone_type_counts, "Suburb", 79);
+    assert_count(&zone_type_counts, "Suburb", 55);
     assert_count(&zone_type_counts, "City", 105);
     assert_count(&zone_type_counts, "StateDistrict", 13);
     assert_count(&zone_type_counts, "State", 0);


### PR DESCRIPTION
Implement LibPostal overrides for the zone type.

There is 2 libpostal kind of overrides:

* override by id:
  for a given `osm_id` (we only handles relations for the moment), there is an explicit type
  eg:
```yaml
    overrides:
        id:
            relation:
                "42": "city_district"
```
  the relation '42' will have the `city_district` type whatever it's admin_level

* override for some 'child':
All zones contained by another zone have a custom set of rules.
eg:
```yaml

    overrides:
        contained_by:
            relation:
                "42":
                    admin_level:
                        "9": "city_district"
                        "10": "suburb""
```
All zones contained by the zone with '42' as osm_id will have a special set of rules for their admin_level mapping.


Since to apply those rules we need to know the inclusions and to create the hierarchy we need the zone_type (to ensure some coherence) we had to change the cosmogony process.

previously we were doing:
* find the ZoneType with libpostal
* find all the inclusions and build the hierarchy while ensuring that a zone cannot be attached to a zone with a 'smaller' ZoneType

now we do:
* find all the zone's inclusions
* find the ZoneType with libpostal using those inclusions
* build the hierarchy while ensuring that a zone cannot be attached to a zone with a 'smaller' ZoneType

This should fix some corner case like Berlin and London