### PR TITLE
Remove untaged zones

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,11 +192,15 @@ fn create_ontology(
 
     type_zones(zones, stats, libpostal_file_path, country_code, &inclusions)?;
 
-    clean_untagged_zones(zones);
-
     build_hierarchy(zones, inclusions);
 
     compute_labels(zones);
+
+    // we remove the useless zones from cosmogony
+    // WARNING: this invalidate the different indexes  (we can no longer lookup a Zone by it's id in the zones's vector)
+    // this should be removed later on (and switch to a map by osm_id ?) as it's not elegant,
+    // but for the moment it'll do
+    clean_untagged_zones(zones);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,13 @@ fn compute_labels(zones: &mut [Zone]) {
     }
 }
 
+// we don't want to keep zone's without zone_type (but the zone_type could be ZoneType::NonAdministrative)
+fn clean_untagged_zones(zones: &mut Vec<zone::Zone>) {
+    zones.retain(|z| z.zone_type.is_some());
+}
+
 fn create_ontology(
-    zones: &mut [zone::Zone],
+    zones: &mut Vec<zone::Zone>,
     stats: &mut CosmogonyStats,
     libpostal_file_path: PathBuf,
     country_code: Option<String>,
@@ -186,6 +191,8 @@ fn create_ontology(
     let inclusions = find_inclusions(zones);
 
     type_zones(zones, stats, libpostal_file_path, country_code, &inclusions)?;
+
+    clean_untagged_zones(zones);
 
     build_hierarchy(zones, inclusions);
 

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -68,7 +68,7 @@ fn test_lux_cosmogony() {
     // from the sample .osm.pbf file,
     let cosmogony = create_cosmogony_for_lux();
     assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
-    assert_eq!(cosmogony.zones.len(), 201);
+    assert_eq!(cosmogony.zones.len(), 198);
 
     assert!(
         cosmogony
@@ -108,7 +108,8 @@ fn test_wrapper_for_lux_admin_levels(a_cosmogony: Cosmogony) {
     assert_count(&level_counts, 8, 105); // 104 + 1 outside LU
     assert_count(&wikidata_counts, 8, 105);
     assert_count(&level_counts, 9, 79);
-    assert_count(&level_counts, 10, 3); // 2 + 1 outside LU
+    // the level 10 is not defined in the libpostal hierarchy, we should not have level 10 admins
+    assert_count(&level_counts, 10, 0);
 }
 
 #[test]
@@ -156,7 +157,7 @@ fn test_lux_zone_types() {
     assert_count(&zone_type_counts, "StateDistrict", 13);
     assert_count(&zone_type_counts, "State", 0);
     assert_count(&zone_type_counts, "Country", 1);
-    assert_count(&zone_type_counts, "None", 3);
+    assert_count(&zone_type_counts, "None", 0); // all the zones without zone_type should be filtered
 
     // check luxembroug city
     let lux = cosmogony


### PR DESCRIPTION
we don't want to keep zone's without zone_type (but the zone_type could
be ZoneType::NonAdministrative)

This way we'll for example remove the admin_level 7 in france that are
not associated to a zone_type and that are often dupplicates

WARNING: this PR introduce quite a trick
this removal invalidates the different zones indexes  (we can no longer lookup a Zone by it's id in the zones's vector)

I think it will be nice to find a nicer solution latern but for the moment it will do