### PR TITLE
Add a `bbox` in zones output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
 name = "cosmogony"
 version = "0.3.0"
 dependencies = [
+ "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ regex = "0.2"
 lazy_static = "1.0.0"
 flate2 = "1.0"
 rayon = "1.0.1"
+
+[dev-dependencies]
+approx = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/README.md
+++ b/README.md
@@ -88,14 +88,16 @@ Below is a brief example of the information contained in the cosmogony output.
 {
 	"zones":[
 		{"id":0,
-		"osm_id":"110114",
+		"osm_id":"relation:110114",
 		"admin_level":8,
 		"zone_type":"city",
 		"name":"Sand Rock",
 		"zip_codes":[],
 		"center":{"coordinates":[-85.77153961457083,34.2303942501858],"type":"Point"},
+		"bbox": [-85.803571, 34.203915, -85.745058, 34.26666],
 		"geometry":{
-			"coordinates":"..."},
+			"coordinates":"..."
+		},
 		"tags":{
 			"admin_level":"8",
 			"border_type":"city",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use geo::Bbox;
 use gst::rtree::Rect;
 use ordered_float::OrderedFloat;
 
-pub fn bbox_to_rect(bbox: Bbox<f64>) -> Rect {
+pub fn bbox_to_rect(bbox: &Bbox<f64>) -> Rect {
     // rust-geo bbox algorithm returns `Bbox`,
     // while gst RTree uses `Rect` as index.
     Rect {

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -9,7 +9,8 @@ extern crate serde_json;
 use self::geos::GGeom;
 use self::itertools::Itertools;
 use self::serde::Serialize;
-use geo::Point;
+use geo::algorithm::boundingbox::BoundingBox;
+use geo::{Bbox, Point};
 use mutable_slice::MutableSlice;
 use osm_boundaries_utils::build_boundary;
 use osmpbfreader::objects::{OsmId, OsmObj, Relation, Tags};
@@ -64,6 +65,11 @@ pub struct Zone {
     )]
     pub boundary: Option<geo::MultiPolygon<f64>>,
 
+    #[serde(
+        serialize_with = "serialize_bbox_as_geojson", deserialize_with = "deserialize_as_bbox"
+    )]
+    pub bbox: Option<Bbox<f64>>,
+
     pub tags: Tags,
     #[serde(default = "Tags::new")] //to keep the retrocompatibility with cosmogony2mimir
     pub center_tags: Tags,
@@ -108,6 +114,7 @@ impl Zone {
             international_names: BTreeMap::default(),
             center: None,
             boundary: None,
+            bbox: None,
             parent: None,
             tags: Tags::new(),
             center_tags: Tags::new(),
@@ -170,6 +177,7 @@ impl Zone {
             zip_codes: zip_codes,
             center: None,
             boundary: None,
+            bbox: None,
             parent: None,
             tags: relation.tags.clone(),
             center_tags: Tags::new(),
@@ -185,6 +193,7 @@ impl Zone {
         use geo::centroid::Centroid;
         Self::from_osm(relation, index).map(|mut result| {
             result.boundary = build_boundary(relation, objects);
+            result.bbox = result.boundary.as_ref().and_then(|b| b.bbox());
 
             let center = relation
                 .refs
@@ -417,6 +426,40 @@ where
     }
 }
 
+fn serialize_bbox_as_geojson<'a, S>(
+    bbox: &'a Option<Bbox<f64>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use self::geojson::Bbox as GeojsonBbox;
+    match bbox {
+        Some(b) => {
+            // bbox serialized as an array (rfc7946)
+            let geojson_bbox: GeojsonBbox = vec![b.xmin, b.ymin, b.xmax, b.ymax];
+            geojson_bbox.serialize(serializer)
+        }
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_as_bbox<'de, D>(d: D) -> Result<Option<Bbox<f64>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use self::serde::Deserialize;
+    Option::<Vec<f64>>::deserialize(d).map(|option| match option {
+        Some(b) => Some(Bbox {
+            xmin: b[0],
+            ymin: b[1],
+            xmax: b[2],
+            ymax: b[3],
+        }),
+        None => None,
+    })
+}
+
 impl Serialize for ZoneIndex {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -473,6 +516,7 @@ mod test {
             international_names: BTreeMap::default(),
             center: None,
             boundary: None,
+            bbox: None,
             parent: parent.map(|p| ZoneIndex { index: p }),
             tags: Tags::new(),
             center_tags: Tags::new(),

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -66,7 +66,9 @@ pub struct Zone {
     pub boundary: Option<geo::MultiPolygon<f64>>,
 
     #[serde(
-        serialize_with = "serialize_bbox_as_geojson", deserialize_with = "deserialize_as_bbox"
+        serialize_with = "serialize_bbox_as_geojson",
+        deserialize_with = "deserialize_as_bbox",
+        default
     )]
     pub bbox: Option<Bbox<f64>>,
 
@@ -436,7 +438,9 @@ where
     use self::geojson::Bbox as GeojsonBbox;
     match bbox {
         Some(b) => {
-            // bbox serialized as an array (rfc7946)
+            // bbox serialized as an array
+            // using GeoJSON bounding box format
+            // See RFC 7946: https://tools.ietf.org/html/rfc7946#section-5
             let geojson_bbox: GeojsonBbox = vec![b.xmin, b.ymin, b.xmax, b.ymax];
             geojson_bbox.serialize(serializer)
         }

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -1,6 +1,8 @@
 extern crate cosmogony;
+extern crate geo;
 extern crate serde_json;
 use cosmogony::{Cosmogony, Zone, ZoneIndex, ZoneType};
+use geo::Bbox;
 
 use std::collections::BTreeMap;
 use std::process::{Command, Output};
@@ -62,26 +64,12 @@ fn create_cosmogony_for_lux() -> Cosmogony {
     return cosmogony;
 }
 
-#[test]
-fn test_lux_cosmogony() {
-    // Check some random values in the built cosmogony
-    // from the sample .osm.pbf file,
-    let cosmogony = create_cosmogony_for_lux();
-    assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
-    assert_eq!(cosmogony.zones.len(), 198);
-
-    assert!(
-        cosmogony
-            .zones
-            .iter()
-            .map(|zone| zone.name.to_owned())
-            .any(|name| name == format!("Esch-sur-Alzette"))
-    );
-}
-
-fn test_wrapper_for_lux_admin_levels(a_cosmogony: Cosmogony) {
-    let level_counts = a_cosmogony.meta.stats.level_counts;
-    let wikidata_counts = a_cosmogony.meta.stats.wikidata_counts;
+fn test_wrapper_for_lux_admin_levels(a_cosmogony: &Cosmogony) {
+    // Ensure that all well-defined (with closed boundaries)
+    // administrative zones are loaded from the sample .osm.pbf file,
+    // with correct counts per admin_level.
+    let level_counts = a_cosmogony.meta.stats.level_counts.clone();
+    let wikidata_counts = a_cosmogony.meta.stats.wikidata_counts.clone();
 
     fn assert_count(counts: &BTreeMap<u32, u64>, key: u32, value: u64) {
         assert_eq!(
@@ -112,18 +100,38 @@ fn test_wrapper_for_lux_admin_levels(a_cosmogony: Cosmogony) {
     assert_count(&level_counts, 10, 0);
 }
 
-#[test]
-fn test_lux_admin_levels() {
-    // Ensure that all well-defined (with closed boundaries)
-    // administrative zones are loaded from the sample .osm.pbf file,
-    // with correct counts per admin_level.
-    let cosmogony = create_cosmogony_for_lux();
+fn test_wrapper_for_lux_zones(a_cosmogony: &Cosmogony) {
+    let lux = a_cosmogony
+        .zones
+        .iter()
+        .find(|z| z.name == "Esch-sur-Alzette" && z.zone_type == Some(ZoneType::City))
+        .unwrap();
 
-    test_wrapper_for_lux_admin_levels(cosmogony);
+    assert_eq!(
+        lux.bbox,
+        Some(Bbox {
+            xmin: 5.9432118,
+            ymin: 49.460907,
+            xmax: 6.005144,
+            ymax: 49.518616,
+        })
+    );
 }
 
 #[test]
-fn test_lux_admin_levels_with_serialisation() {
+fn test_lux_cosmogony() {
+    // Check some random values in the built cosmogony
+    // from the sample .osm.pbf file,
+    let cosmogony = create_cosmogony_for_lux();
+    assert_eq!(cosmogony.meta.osm_filename, "luxembourg_filtered.osm.pbf");
+    assert_eq!(cosmogony.zones.len(), 198);
+
+    test_wrapper_for_lux_admin_levels(&cosmogony);
+    test_wrapper_for_lux_zones(&cosmogony);
+}
+
+#[test]
+fn test_lux_cosmogony_with_serialisation() {
     // Serialize and deserialize a built cosmogony
     // and check again the admin_level counts.
     let cosmogony = create_cosmogony_for_lux();
@@ -131,7 +139,8 @@ fn test_lux_admin_levels_with_serialisation() {
     let cosmogony_as_json = serde_json::to_string(&cosmogony).unwrap();
     let cosmogony_from_json: Cosmogony = serde_json::from_str(&cosmogony_as_json).unwrap();
 
-    test_wrapper_for_lux_admin_levels(cosmogony_from_json);
+    test_wrapper_for_lux_admin_levels(&cosmogony_from_json);
+    test_wrapper_for_lux_zones(&cosmogony_from_json);
 }
 
 fn get_zone<'a>(cosmogony: &'a Cosmogony, idx: &'a ZoneIndex) -> Option<&'a Zone> {

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -2,7 +2,9 @@ extern crate cosmogony;
 extern crate geo;
 extern crate serde_json;
 use cosmogony::{Cosmogony, Zone, ZoneIndex, ZoneType};
-use geo::Bbox;
+
+#[macro_use]
+extern crate approx;
 
 use std::collections::BTreeMap;
 use std::process::{Command, Output};
@@ -101,21 +103,17 @@ fn test_wrapper_for_lux_admin_levels(a_cosmogony: &Cosmogony) {
 }
 
 fn test_wrapper_for_lux_zones(a_cosmogony: &Cosmogony) {
-    let lux = a_cosmogony
+    let zone = a_cosmogony
         .zones
         .iter()
         .find(|z| z.name == "Esch-sur-Alzette" && z.zone_type == Some(ZoneType::City))
         .unwrap();
 
-    assert_eq!(
-        lux.bbox,
-        Some(Bbox {
-            xmin: 5.9432118,
-            ymin: 49.460907,
-            xmax: 6.005144,
-            ymax: 49.518616,
-        })
-    );
+    let bbox = zone.bbox.unwrap();
+    assert_relative_eq!(bbox.xmin, 5.9432118, epsilon = 1e-8);
+    assert_relative_eq!(bbox.ymin, 49.460907, epsilon = 1e-8);
+    assert_relative_eq!(bbox.xmax, 6.005144, epsilon = 1e-8);
+    assert_relative_eq!(bbox.ymax, 49.518616, epsilon = 1e-8);
 }
 
 #[test]

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -1,5 +1,4 @@
 extern crate cosmogony;
-extern crate geo;
 extern crate serde_json;
 use cosmogony::{Cosmogony, Zone, ZoneIndex, ZoneType};
 


### PR DESCRIPTION
A new `bbox` field is part of the `Zone` struct and is serialized in the output file.  
The output format follows GeoJson specification ("bbox" is an array of 4 floats : `[xmin, ymin, xmax, ymax]`), although it is not nested in the `geometry` object to ease the serialization/deserialization process.


Note that this PR includes some refactoring in tests/ to run similar checks with and without serialization of the cosmogony output.
