### PR TITLE
Direct serialization to output file

### DIFF
--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -91,17 +91,18 @@ fn serialize_cosmogony(
 ) -> Result<(), Error> {
     info!("serializing the cosmogony");
     let json = serde_json::to_string(cosmogony)?;
-    let output_bytes = match format {
-        OutputFormat::JsonGz => {
-            let mut e = GzEncoder::new(vec![], Compression::default());
-            e.write_all(json.as_bytes())?;
-            e.finish()?
-        }
-        OutputFormat::Json => json.into_bytes(),
-    };
     info!("writing the output file {}", output_file);
     let mut file = File::create(output_file)?;
-    file.write_all(&output_bytes)?;
+    match format {
+        OutputFormat::JsonGz => {
+            let mut e = GzEncoder::new(file, Compression::default());
+            e.write_all(json.as_bytes())?;
+            e.finish()?;
+        }
+        OutputFormat::Json => {
+            file.write_all(&json.into_bytes())?;
+        }
+    };
     Ok(())
 }
 


### PR DESCRIPTION
* Use serde_json::to_writer to skip the serialization in RAM
* Wrap the file in a BufWriter to avoid buffering issues