### PR TITLE
add taginfo file to let OSMers know which tags we use

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -1,0 +1,44 @@
+{
+    "data_format": 1,
+    "project": {
+        "name": "Cosmogony",
+        "description": "Easy to use & easy to update geographic regions",
+        "project_url": "http://cosmogony.world",
+        "doc_url": "https://github.com/osm-without-borders/cosmogony",
+        "contact_name": "Noémie Lehuby",
+        "contact_email": "n.lehuby@qwant.com"
+    },
+    "tags": [{
+            "key": "boundary",
+            "value": "administrative",
+            "object_types": ["relation"],
+            "description": "to filter administrative zones"
+        },
+        {
+            "key": "ISO3166-1:alpha2",
+            "object_types": ["relation"],
+            "description": "to get the country of the administrative zone"
+        },
+        {
+            "key": "admin_level",
+            "object_types": ["relation"],
+            "description": "to build a hierarchy of administrative zones"
+        },
+        {
+            "key": "name",
+            "object_types": ["relation"]
+        },
+        {
+            "key": "wikidata",
+            "object_types": ["relation"]
+        },
+        {
+            "key": "postal_code",
+            "object_types": ["relation"]
+        },
+        {
+            "key": "addr:postcode",
+            "object_types": ["relation"]
+        }
+    ]
+}


### PR DESCRIPTION
Taginfo is a very useful project to learn about tags in OSM, and you can use it to know what the tags are used to.

this PR add a taginfo file for our project, so it can be displayed in the pages for the tags we use.

The documentation for the file format can be found here : https://wiki.openstreetmap.org/wiki/Taginfo/Projects

I didn't add all the tags we use in here, because this does not have to replace our documentation, it is mainly a way to advertise our project and how to map in OSM to use it ;)