### PR TITLE
Exclude country codes with no libpostal rules in CountryFinder 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ fn get_country_code<'a>(
     inclusions: &Vec<ZoneIndex>,
 ) -> Option<String> {
     if let &Some(ref c) = country_code {
-        Some(c.clone())
+        Some(c.to_uppercase())
     } else {
         country_finder.find_zone_country(&zone, &inclusions)
     }
@@ -128,8 +128,9 @@ fn type_zones(
     use rayon::prelude::*;
     info!("reading libpostal's rules");
     let zone_typer = zone_typer::ZoneTyper::new(libpostal_file_path)?;
+
     info!("creating a countrys rtree");
-    let country_finder: CountryFinder = zones.iter().collect();
+    let country_finder: CountryFinder = CountryFinder::init(&zones, &zone_typer);
     if country_code.is_none() && country_finder.is_empty() {
         return Err(failure::err_msg(
             "no country_code has been provided and no country have been found, we won't be able to make a cosmogony",

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -11,7 +11,7 @@ use zone::{Zone, ZoneIndex, ZoneType};
 
 #[derive(Debug)]
 pub struct ZoneTyper {
-    countries_rules: BTreeMap<String, CountryAdminTypeRules>,
+    pub countries_rules: BTreeMap<String, CountryAdminTypeRules>,
 }
 
 #[derive(Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug)]
@@ -42,7 +42,7 @@ struct RulesOverrides {
 }
 
 #[derive(Deserialize, Debug)]
-struct CountryAdminTypeRules {
+pub struct CountryAdminTypeRules {
     #[serde(rename = "admin_level", default)]
     type_by_level: BTreeMap<String, ZoneType>,
     #[serde(
@@ -87,8 +87,9 @@ impl ZoneTyper {
         zone_inclusions: &Vec<ZoneIndex>,
         all_zones: &[Zone],
     ) -> Result<ZoneType, ZoneTyperError> {
-        let country_rules = self.countries_rules
-            .get(&country_code.to_lowercase()) // file postal code are lowercase
+        let country_rules = self
+            .countries_rules
+            .get(country_code)
             .ok_or(ZoneTyperError::InvalidCountry(country_code.to_string()))?;
         Ok(country_rules
             .get_zone_type(zone, zone_inclusions, all_zones)
@@ -195,7 +196,7 @@ where
             })
             .ok()?;
 
-        Some((country_code, deserialized_level))
+        Some((country_code.to_uppercase(), deserialized_level))
     };
 
     Ok(fs::read_dir(&yaml_files_folder)


### PR DESCRIPTION
This is the first step to solve issues with zones that are contained into multiple country codes.  
Only country codes with boundaries rules from libpostal are now stored in `CountryFinder`.
  
Rules from the most specific country code (with the highest admin_level) are still applied, but it is now possible to ignore some country code by removing the corresponding .yml file.

This has been done in https://github.com/osm-without-borders/libpostal/pull/5 to remove specific rules about DOMs in France.
