### PR TITLE
Compute the osm places shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "geo 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "geos 2.0.3 (git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8)",
+ "geos 3.0.0 (git+https://github.com/antoine-de/rust-geos.git?rev=09aeb1aff841b9a321fa8c205234d03ea8f73cba)",
  "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,8 +381,8 @@ dependencies = [
 
 [[package]]
 name = "geos"
-version = "2.0.3"
-source = "git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8#a20f6d891bbe09e1b917b2b5b0a3fad8720dfbd2"
+version = "3.0.0"
+source = "git+https://github.com/antoine-de/rust-geos.git?rev=09aeb1aff841b9a321fa8c205234d03ea8f73cba#09aeb1aff841b9a321fa8c205234d03ea8f73cba"
 dependencies = [
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1223,7 +1223,7 @@ dependencies = [
 "checksum geo 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d86629c1eb1a317eb0c73533d0a7d96143cc2ec405653ff38e9b8f3b6a10699a"
 "checksum geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7260ac8abfc04cc21b914254b69875c2548faf6f791f88ad9ec1a131d4251729"
 "checksum geojson 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa4fb54bb359e2b2a473704f676c917769faf06f57ddc33ccaadc83d05ea936d"
-"checksum geos 2.0.3 (git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8)" = "<none>"
+"checksum geos 3.0.0 (git+https://github.com/antoine-de/rust-geos.git?rev=09aeb1aff841b9a321fa8c205234d03ea8f73cba)" = "<none>"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89d64d16c4e0ab924799d713bf939dd16a2e9d3e71afe9f2b2977f38a04e0188"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,13 +87,35 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytecount"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo_metadata"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cc"
@@ -144,22 +166,23 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "geos 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geojson 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geos 2.0.3 (git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8)",
  "gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "osm_boundaries_utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osm_boundaries_utils 0.3.0 (git+https://github.com/QwantResearch/osm_boundaries_utils_rs.git?rev=86374bbfc75798dd836c85214f72b35562bae23a)",
  "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -235,22 +258,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.1"
+name = "error-chain"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -318,39 +350,55 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.6.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spade 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "spade 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "geojson"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "geos"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "2.0.3"
+source = "git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8#a20f6d891bbe09e1b917b2b5b0a3fad8720dfbd2"
 dependencies = [
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skeptic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wkt 0.2.0 (git+https://github.com/georust/wkt.git?rev=e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gst"
@@ -561,10 +609,11 @@ dependencies = [
 
 [[package]]
 name = "osm_boundaries_utils"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.3.0"
+source = "git+https://github.com/QwantResearch/osm_boundaries_utils_rs.git?rev=86374bbfc75798dd836c85214f72b35562bae23a#86374bbfc75798dd836c85214f72b35562bae23a"
 dependencies = [
- "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -603,7 +652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.6"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -625,6 +674,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,7 +696,7 @@ name = "quote"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -759,6 +816,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rental"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,8 +853,30 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scopeguard"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -802,7 +889,7 @@ name = "serde_derive"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -829,9 +916,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "0.6.2"
+name = "skeptic"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "spade"
@@ -843,7 +948,7 @@ dependencies = [
  "nalgebra 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -888,7 +993,17 @@ name = "syn"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -903,11 +1018,22 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.6.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -994,6 +1120,16 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1144,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1162,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wkt"
+version = "0.2.0"
+source = "git+https://github.com/georust/wkt.git?rev=e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2#e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2"
+dependencies = [
+ "geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1039,8 +1191,11 @@ dependencies = [
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
+"checksum cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1efca0b863ca03ed4c109fb1c55e0bc4bbeb221d3e103d86251046b06a526bd0"
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
@@ -1054,8 +1209,9 @@ dependencies = [
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"
-"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
-"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
+"checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum flat_map 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5552990c1ea625d3786cbc2899c388b27e9ccdf5054dd16301b156c6e85d7a45"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fac2277e84e5e858483756647a9d0aa8d9a2b7cba517fd84325a0aaa69a0909"
@@ -1064,9 +1220,11 @@ dependencies = [
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
-"checksum geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3f587a8e7ce8b1633c44a4a24bbeb6dad09f1db740ec335a072e7a1eeb6de8"
-"checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
-"checksum geos 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aeaa37068bddb1783cf559ec6c23dcfa49a50b09b93158e5219b431460f6419c"
+"checksum geo 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d86629c1eb1a317eb0c73533d0a7d96143cc2ec405653ff38e9b8f3b6a10699a"
+"checksum geo-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7260ac8abfc04cc21b914254b69875c2548faf6f791f88ad9ec1a131d4251729"
+"checksum geojson 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa4fb54bb359e2b2a473704f676c917769faf06f57ddc33ccaadc83d05ea936d"
+"checksum geos 2.0.3 (git+https://github.com/antoine-de/rust-geos.git?rev=a20f6d8)" = "<none>"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum gst 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89d64d16c4e0ab924799d713bf939dd16a2e9d3e71afe9f2b2977f38a04e0188"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
@@ -1093,14 +1251,15 @@ dependencies = [
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e312d9bf410688e9c292d9e7da4567143c0ad18df8fceb6ce99156f40cef2"
-"checksum osm_boundaries_utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "581c63c286c423c973b7a81e4507cc219956b1fb2d8bd8d58c3b63b1e64a7b2a"
+"checksum osm_boundaries_utils 0.3.0 (git+https://github.com/QwantResearch/osm_boundaries_utils_rs.git?rev=86374bbfc75798dd836c85214f72b35562bae23a)" = "<none>"
 "checksum osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bda4b6655f97c1ed0f0e93a95bc231de3b519364d389496092353b2a9bd478d0"
 "checksum par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2f05b290991702bb8140cf70915b82b0ae1ec7fe478db97305af990048040095"
 "checksum pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
-"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
+"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum procedural-masquerade 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1bcafee1590f81acb329ae45ec627b318123f085153913620316ae9a144b2a"
 "checksum protobuf 1.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0100b2cf4cd80bbe249f32146ddb767829da85fdda0ea79c570359620a8933e8"
 "checksum pub-iterator-type 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "858afdbecdce657c6e32031348cf7326da7700c869c368a136d31565972f7018"
+"checksum pulldown-cmark 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fdf85cda6cadfae5428a54661d431330b312bc767ddbc57adbedc24da66e32"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
@@ -1117,16 +1276,21 @@ dependencies = [
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05b06a75f5217880fc5e905952a42750bf44787e56a6c6d6852ed0992f5e1d54"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rental 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f098d5bfcbc5b929baf992ca6e09244daf4b47d1aedba3a808364faf48bd036e"
 "checksum rental-impl 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "cb24fb6b34fdd7b264154ea85c34bf9d3a9ac1355163b6e22ab8262f9f4a73f1"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95"
 "checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
 "checksum serde_json 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "eb40600c756f02d7ea34943626cefa85732fdae5f95b90b31f9797b3c526d1e6"
 "checksum serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
-"checksum smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "312a7df010092e73d6bbaf141957e868d4f30efd2bfd9bb1028ad91abec58514"
+"checksum skeptic 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4474d6da9593171bcb086890fc344a3a12783cb24e5b141f8a5d0e43561f4b6"
+"checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum spade 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aedac88b4bccfaf382acc46981681afc6f2181d47e1f13a31039d07c70ef8d00"
 "checksum stable_deref_trait 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbc596e092fe5f598b12ef46cc03754085ac2f4d8c739ad61c4ae266cc3b3fa"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
@@ -1134,8 +1298,10 @@ dependencies = [
 "checksum structopt-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4da119c9a7a1eccb7c6de0c1eb3f7ed1c11138624d092b3687222aeed8f1375c"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
+"checksum syn 0.15.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0b78d53b5e1b6e63129140b1336877c3bddbae398c7956150396bdad0e28676c"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
@@ -1149,8 +1315,11 @@ dependencies = [
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ffb549f212c31e19f3667c55a7f515b983a84aef10fd0a4d1f9c125425115f3"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
+"checksum wkt 0.2.0 (git+https://github.com/georust/wkt.git?rev=e7e388720fcf76d8b104b6ac2b0c9c4dc636aac2)" = "<none>"
 "checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,7 @@ failure_derive = "0.1"
 gst = "0.1.3"
 ordered-float = "0.0.2"
 osm_boundaries_utils = { version="0.3", git = "https://github.com/QwantResearch/osm_boundaries_utils_rs.git", rev = "86374bbfc75798dd836c85214f72b35562bae23a" }
-# osm_boundaries_utils = "0.3"
-# geos = "~1.0"
-geos = { version="2.0.3", git = "https://github.com/antoine-de/rust-geos.git", rev = "a20f6d8" }
+geos = { version="3.0", git = "https://github.com/antoine-de/rust-geos.git", rev = "09aeb1aff841b9a321fa8c205234d03ea8f73cba" }
 regex = "0.2"
 lazy_static = "1.0.0"
 flate2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"
@@ -17,7 +17,8 @@ travis-ci = { repository = "osm-without-borders/cosmogony" }
 [dependencies]
 log = "0.4"
 env_logger = "0.5"
-geo = "0.6"
+geo = "0.10.2"
+geo-types = "0.2.0"
 structopt = "0.1"
 structopt-derive = "0.1"
 osmpbfreader = "^0.11"
@@ -26,13 +27,15 @@ serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.7"
 itertools = "0.7"
-geojson = "0.9"
+geojson = "0.12.0"
 failure = "0.1"
 failure_derive = "0.1"
 gst = "0.1.3"
 ordered-float = "0.0.2"
-osm_boundaries_utils = "0.2"
-geos = "~1.0"
+osm_boundaries_utils = { version="0.3", git = "https://github.com/QwantResearch/osm_boundaries_utils_rs.git", rev = "86374bbfc75798dd836c85214f72b35562bae23a" }
+# osm_boundaries_utils = "0.3"
+# geos = "~1.0"
+geos = { version="2.0.3", git = "https://github.com/antoine-de/rust-geos.git", rev = "a20f6d8" }
 regex = "0.2"
 lazy_static = "1.0.0"
 flate2 = "1.0"

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -1,38 +1,55 @@
+use failure::ResultExt;
+use geo_types::{Coordinate, MultiPolygon, Point, Polygon, Rect};
 use osmpbfreader::{OsmId, OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::path::Path;
 use zone::{Zone, ZoneIndex, ZoneType};
 use zone_tree::ZonesTree;
-use geos;
-use geo_types::Point;
 
-pub fn compute_additional_cities(zones: &mut Vec<Zone>, pbf_reader: &mut OsmPbfReader<File>) {
-    let place_zones = read_places(pbf_reader);
-    info!("there are {} places, we'll try to make boundaries for them",place_zones.len());
+pub fn compute_additional_cities(zones: &mut Vec<Zone>, pbf_path: &str) {
+    let place_zones = read_places(pbf_path);
+    info!(
+        "there are {} places, we'll try to make boundaries for them",
+        place_zones.len()
+    );
     let zones_rtree: ZonesTree = zones.iter().filter(|z| z.is_admin()).collect();
 
     let new_cities: Vec<Zone> = {
         let mut candidate_parent_zones: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for (parent, place) in place_zones
             .into_iter()
-            .filter_map(|place| get_parent(&place, &zones, &zones_rtree).map(|parent| (parent, place)))
-            .filter(|(parent, _)| parent.zone_type == Some(ZoneType::City))
-        {
+            .filter_map(|place| {
+                get_parent(&place, &zones, &zones_rtree).map(|parent| {
+                    info!(
+                        "on a trouve le parent {:?} / {:?} for {:?}",
+                        &parent.id, &parent.zone_type, place.id
+                    );
+                    (parent, place)
+                })
+            }).filter(|(parent, _)| {
+                parent.zone_type != Some(ZoneType::City)
+                    && parent.zone_type != Some(ZoneType::Suburb)
+            }) {
             candidate_parent_zones
                 .entry(&parent.id)
                 .or_default()
                 .push(place);
         }
 
-        info!("We'll compute voronois partitions for {} parent zones", candidate_parent_zones.len());
+        info!(
+            "We'll compute voronois partitions for {} parent zones",
+            candidate_parent_zones.len()
+        );
 
-        candidate_parent_zones.into_iter() //TODO into_par_iter
-        .map(|(parent, places)| compute_voronoi(parent, places, &zones))
-        .flatten()
-        // .map_err(|e| error!("error while computing voronoi : {}", e))
-        .collect()
+        candidate_parent_zones
+            .into_iter() //TODO into_par_iter
+            .map(|(parent, places)| compute_voronoi(parent, places, &zones))
+            .flatten()
+            // .map_err(|e| error!("error while computing voronoi : {}", e))
+            .collect()
     };
-    
+
     publish_new_cities(zones, new_cities);
 }
 
@@ -41,7 +58,7 @@ fn get_parent<'a>(place: &Zone, zones: &'a [Zone], zones_rtree: &ZonesTree) -> O
         .fetch_zone_bbox(&place)
         .into_iter()
         .map(|z_idx| &zones[z_idx.index])
-        .filter(|z| z.contains(place))
+        .filter(|z| z.contains_center(place))
         .min_by_key(|z| z.zone_type)
 }
 
@@ -55,10 +72,14 @@ fn is_place(obj: &OsmObj) -> bool {
     }
 }
 
-fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
+fn read_places(pbf_path: &str) -> Vec<Zone> {
+    let path = Path::new(&pbf_path);
+    let file = File::open(&path).context("no pbf file").unwrap(); //TODO remove unwrap
+
+    let mut parsed_pbf = OsmPbfReader::new(file);
     let mut zones = vec![];
 
-    for obj in pbf_reader.par_iter().map(Result::unwrap) {
+    for obj in parsed_pbf.par_iter().map(Result::unwrap) {
         if !is_place(&obj) {
             continue;
         }
@@ -68,6 +89,16 @@ fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
             if let Some(mut zone) = Zone::from_osm(&node.tags, next_index, osm_id) {
                 zone.zone_type = Some(ZoneType::City);
                 zone.center = Some(Point::<f64>::new(node.lon(), node.lat()));
+                zone.bbox = zone.center.as_ref().map(|p| Rect {
+                    min: Coordinate {
+                        x: p.0.x - std::f64::EPSILON,
+                        y: p.0.y - std::f64::EPSILON,
+                    },
+                    max: Coordinate {
+                        x: p.0.x + std::f64::EPSILON,
+                        y: p.0.y + std::f64::EPSILON,
+                    },
+                });
                 zones.push(zone);
             }
         }
@@ -75,10 +106,43 @@ fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
     zones
 }
 
-fn compute_voronoi(parent: &ZoneIndex, places: Vec<Zone>, zones: &[Zone]) -> Vec<Zone> {
+fn compute_voronoi(parent: &ZoneIndex, mut places: Vec<Zone>, zones: &[Zone]) -> Vec<Zone> {
+    //TODO remove this collect by changing the compute_voronoi function signature
+    let points: Vec<Point<_>> = places.iter().filter_map(|p| p.center).collect();
 
-    // let points = places.iter().map(|p| p)
-    unimplemented!()
+    let voronois = geos::compute_voronoi(&points, 0.).unwrap(); //TODO remove unwrap
+
+    let calc_geom = create_forbidden_geom(&zones[parent.index]);
+    for (idx, voronoi) in voronois.into_iter().enumerate() {
+        let place: &mut Zone = &mut places[idx];
+
+        place.boundary = make_boundary(voronoi, &calc_geom);
+        //TODO compute the bounding box
+        place.parent = Some(parent.clone());
+    }
+    places
+        .into_iter()
+        .filter(|z| z.boundary.is_some())
+        .collect() // TODO remove this collect
+
+    //TODO if possible zip it
+    // for (ref mut place, voronoi) in places.iter_mut().filter(|p| p.center.is_some()).zip(voronois.into_iter()){
+    // };
+}
+
+/// Create a multipolygon with the boundary of the parent zone + all the cities with real boundaries from this zone
+/// This will be use to extract this geometry from the
+fn create_forbidden_geom(parent_zone: &Zone) -> Option<MultiPolygon<f64>> {
+    //TODO
+    None
+}
+
+fn make_boundary(
+    voronoi: Polygon<f64>,
+    geom_to_extract: &Option<MultiPolygon<f64>>,
+) -> Option<MultiPolygon<f64>> {
+    // TODO extract the geom from the voronoi
+    Some(MultiPolygon(vec![voronoi]))
 }
 
 fn publish_new_cities(zones: &mut Vec<Zone>, new_cities: Vec<Zone>) {

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -1,0 +1,85 @@
+extern crate geos;
+use osmpbfreader::{OsmId, OsmObj, OsmPbfReader};
+use std::collections::BTreeMap;
+use std::fs::File;
+use zone::{Zone, ZoneIndex, ZoneType};
+use zone_tree::ZonesTree;
+
+pub fn compute_additional_cities(zones: &mut Vec<Zone>, pbf_reader: &mut OsmPbfReader<File>) {
+    let place_zones = read_places(pbf_reader);
+    info!("there are {} places, we'll try to make boundaries for them",place_zones.len());
+    let zones_rtree: ZonesTree = zones.iter().filter(|z| z.is_admin()).collect();
+
+    let new_cities: Vec<Zone> = {
+        let mut candidate_parent_zones: BTreeMap<_, Vec<_>> = BTreeMap::new();
+        for (parent, place) in place_zones
+            .into_iter()
+            .filter_map(|place| get_parent(&place, &zones, &zones_rtree).map(|parent| (parent, place)))
+            .filter(|(parent, _)| parent.zone_type == Some(ZoneType::City))
+        {
+            candidate_parent_zones
+                .entry(&parent.id)
+                .or_default()
+                .push(place);
+        }
+
+        info!("We'll compute voronois partitions for {} parent zones", candidate_parent_zones.len());
+
+        candidate_parent_zones.into_iter() //TODO into_par_iter
+        .map(|(parent, places)| compute_voronoi(parent, places, &zones))
+        .flatten()
+        // .map_err(|e| error!("error while computing voronoi : {}", e))
+        .collect()
+    };
+    
+    publish_new_cities(zones, new_cities);
+}
+
+fn get_parent<'a>(place: &Zone, zones: &'a [Zone], zones_rtree: &ZonesTree) -> Option<&'a Zone> {
+    zones_rtree
+        .fetch_zone_bbox(&place)
+        .into_iter()
+        .map(|z_idx| &zones[z_idx.index])
+        .filter(|z| z.contains(place))
+        .min_by_key(|z| z.zone_type)
+}
+
+fn is_place(obj: &OsmObj) -> bool {
+    match *obj {
+        OsmObj::Node(ref node) => node
+            .tags
+            .get("place")
+            .map_or(false, |v| v == "city" || v == "town"),
+        _ => false,
+    }
+}
+
+fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
+    let mut zones = vec![];
+
+    for obj in pbf_reader.par_iter().map(Result::unwrap) {
+        if !is_place(&obj) {
+            continue;
+        }
+        if let OsmObj::Node(ref node) = obj {
+            let osm_id = OsmId::Node(node.id);
+            let next_index = ZoneIndex { index: zones.len() };
+            if let Some(mut zone) = Zone::from_osm(&node.tags, next_index, osm_id) {
+                zone.zone_type = Some(ZoneType::City);
+                zones.push(zone);
+            }
+        }
+    }
+    zones
+}
+
+fn compute_voronoi(parent: &ZoneIndex, place: Vec<Zone>, zones: &[Zone]) -> Vec<Zone> {
+    unimplemented!()
+}
+
+fn publish_new_cities(zones: &mut Vec<Zone>, new_cities: Vec<Zone>) {
+    for mut city in new_cities {
+        city.id = ZoneIndex { index: zones.len() };
+        zones.push(city);
+    }
+}

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -1,9 +1,10 @@
-extern crate geos;
 use osmpbfreader::{OsmId, OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
 use std::fs::File;
 use zone::{Zone, ZoneIndex, ZoneType};
 use zone_tree::ZonesTree;
+use geos;
+use geo_types::Point;
 
 pub fn compute_additional_cities(zones: &mut Vec<Zone>, pbf_reader: &mut OsmPbfReader<File>) {
     let place_zones = read_places(pbf_reader);
@@ -66,6 +67,7 @@ fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
             let next_index = ZoneIndex { index: zones.len() };
             if let Some(mut zone) = Zone::from_osm(&node.tags, next_index, osm_id) {
                 zone.zone_type = Some(ZoneType::City);
+                zone.center = Some(Point::<f64>::new(node.lon(), node.lat()));
                 zones.push(zone);
             }
         }
@@ -73,7 +75,9 @@ fn read_places(pbf_reader: &mut OsmPbfReader<File>) -> Vec<Zone> {
     zones
 }
 
-fn compute_voronoi(parent: &ZoneIndex, place: Vec<Zone>, zones: &[Zone]) -> Vec<Zone> {
+fn compute_voronoi(parent: &ZoneIndex, places: Vec<Zone>, zones: &[Zone]) -> Vec<Zone> {
+
+    // let points = places.iter().map(|p| p)
     unimplemented!()
 }
 

--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -150,7 +150,7 @@ fn main() {
     match cosmogony(args) {
         Err(e) => {
             error!("cosmogony in error! {:?}", e);
-            e.causes().for_each(|c| {
+            e.iter_chain().for_each(|c| {
                 error!("{}", c);
                 if let Some(b) = c.backtrace() {
                     error!("  - {}", b);

--- a/src/country_finder.rs
+++ b/src/country_finder.rs
@@ -44,8 +44,7 @@ impl CountryFinder {
                                 },
                             )
                         })
-                })
-                .collect(),
+                }).collect(),
         }
     }
 

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -67,8 +67,8 @@ pub fn build_hierarchy(zones: &mut [Zone], inclusions: Vec<Vec<ZoneIndex>>) {
 
 #[cfg(test)]
 mod test {
-    use geo::boundingbox::BoundingBox;
-    use geo::{LineString, MultiPolygon, Point, Polygon};
+    use geo::bounding_rect::BoundingRect;
+    use geo_types::{LineString, MultiPolygon, Point, Polygon, Coordinate};
     use hierarchy_builder::{build_hierarchy, find_inclusions};
     use zone::{Zone, ZoneType};
 
@@ -79,47 +79,51 @@ mod test {
         let mut z = Zone::default();
         z.id.index = idx;
         z.boundary = Some(mp);
-        z.bbox = z.boundary.as_ref().and_then(|b| b.bbox());
+        z.bbox = z.boundary.as_ref().and_then(|b| b.bounding_rect());
         z.zone_type = zone_type;
         z
     }
 
+    fn coords(tuples: Vec<(f64, f64)>) -> Vec<Coordinate<f64>> {
+        tuples.into_iter().map(Coordinate::from).collect()
+    }
+
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn create_zones() -> Vec<Zone> {
-        let l0 = LineString(vec![
-            Point::new(0., 0.),     //  +------+
-            Point::new(0., 10.),    //  |      |
-            Point::new(10., 10.),   //  |  z0  |
-            Point::new(10., 0.),    //  |      |
-            Point::new(0., 0.),     //  +------+
-        ]);
+        let l0 = LineString(coords(vec![
+            (0., 0.),     //  +------+
+            (0., 10.),    //  |      |
+            (10., 10.),   //  |  z0  |
+            (10., 0.),    //  |      |
+            (0., 0.),     //  +------+
+        ]));
         let z0 = zone_factory(0, l0, Some(ZoneType::Country));
 
-        let l1 = LineString(vec![
-            Point::new(1., 1.),     //  +------+
-            Point::new(1., 9.),     //  |+----+|
-            Point::new(9., 9.),     //  || z1 ||
-            Point::new(9., 1.),     //  |+----+|
-            Point::new(1., 1.),     //  +------+
-        ]);
+        let l1 = LineString(coords(vec![
+            (1., 1.),     //  +------+
+            (1., 9.),     //  |+----+|
+            (9., 9.),     //  || z1 ||
+            (9., 1.),     //  |+----+|
+            (1., 1.),     //  +------+
+        ]));
         let z1 = zone_factory(1, l1, Some(ZoneType::State));
 
-        let l2 = LineString(vec![
-            Point::new(2., 2.),     //  +------+
-            Point::new(2., 8.),     //  |      |
-            Point::new(8., 8.),     //  |  []<---- z2
-            Point::new(8., 2.),     //  |      |
-            Point::new(2., 2.),     //  +------+
-        ]);
+        let l2 = LineString(coords(vec![
+            (2., 2.),     //  +------+
+            (2., 8.),     //  |      |
+            (8., 8.),     //  |  []<---- z2
+            (8., 2.),     //  |      |
+            (2., 2.),     //  +------+
+        ]));
         let z2 = zone_factory(2, l2, Some(ZoneType::City));
 
-        let l3 = LineString(vec![
-            Point::new(0., 0.),     //  +------+
-            Point::new(0., 5.),     //  |      |
-            Point::new(10., 5.),    //  +------+
-            Point::new(10., 0.),    //  |  z3  |
-            Point::new(0., 0.),     //  +------+
-        ]);
+        let l3 = LineString(coords(vec![
+            (0., 0.),     //  +------+
+            (0., 5.),     //  |      |
+            (10., 5.),    //  +------+
+            (10., 0.),    //  |  z3  |
+            (0., 0.),     //  +------+
+        ]));
         let z3 = zone_factory(3, l3, Some(ZoneType::State));
 
         vec![z0, z1, z2, z3]

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -68,7 +68,7 @@ pub fn build_hierarchy(zones: &mut [Zone], inclusions: Vec<Vec<ZoneIndex>>) {
 #[cfg(test)]
 mod test {
     use geo::bounding_rect::BoundingRect;
-    use geo_types::{LineString, MultiPolygon, Point, Polygon, Coordinate};
+    use geo_types::{Coordinate, LineString, MultiPolygon, Polygon};
     use hierarchy_builder::{build_hierarchy, find_inclusions};
     use zone::{Zone, ZoneType};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate failure;
 extern crate geo;
+extern crate geo_types;
 extern crate gst;
 #[macro_use]
 extern crate log;
@@ -16,6 +17,7 @@ extern crate structopt;
 #[macro_use]
 extern crate lazy_static;
 extern crate rayon;
+extern crate geos;
 
 mod additional_zones;
 pub mod cosmogony;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ extern crate serde_yaml;
 extern crate structopt;
 #[macro_use]
 extern crate lazy_static;
-extern crate rayon;
 extern crate geos;
+extern crate rayon;
 
 mod additional_zones;
 pub mod cosmogony;
@@ -211,7 +211,7 @@ fn create_ontology(
     stats: &mut CosmogonyStats,
     libpostal_file_path: PathBuf,
     country_code: Option<String>,
-    pbf_reader: &mut OsmPbfReader<File>,
+    pbf_path: &str,
 ) -> Result<(), Error> {
     info!("creating ontology for {} zones", zones.len());
     let inclusions = find_inclusions(zones);
@@ -220,7 +220,7 @@ fn create_ontology(
 
     build_hierarchy(zones, inclusions);
 
-    compute_additional_cities(zones, pbf_reader);
+    compute_additional_cities(zones, pbf_path);
 
     compute_labels(zones);
 
@@ -255,7 +255,7 @@ pub fn build_cosmogony(
         &mut stats,
         libpostal_file_path,
         country_code,
-        &mut parsed_pbf,
+        &pbf_path,
     )?;
 
     stats.compute(&zones);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,17 +1,17 @@
 extern crate geo;
 
-use geo::Bbox;
-use gst::rtree::Rect;
+use geo_types;
+use gst;
 use ordered_float::OrderedFloat;
 
-pub fn bbox_to_rect(bbox: &Bbox<f64>) -> Rect {
+pub fn bbox_to_rect(bbox: &geo_types::Rect<f64>) -> gst::rtree::Rect {
     // rust-geo bbox algorithm returns `Bbox`,
     // while gst RTree uses `Rect` as index.
-    Rect {
-        xmin: OrderedFloat(down(bbox.xmin as f32)),
-        xmax: OrderedFloat(up(bbox.xmax as f32)),
-        ymin: OrderedFloat(down(bbox.ymin as f32)),
-        ymax: OrderedFloat(up(bbox.ymax as f32)),
+    gst::rtree::Rect {
+        xmin: OrderedFloat(down(bbox.min.x as f32)),
+        xmax: OrderedFloat(up(bbox.max.x as f32)),
+        ymin: OrderedFloat(down(bbox.min.y as f32)),
+        ymax: OrderedFloat(up(bbox.max.y as f32)),
     }
 }
 

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -5,18 +5,18 @@ extern crate regex;
 extern crate serde;
 extern crate serde_json;
 
-use geos::GGeom;
 use self::itertools::Itertools;
 use self::serde::Serialize;
 use geo::algorithm::bounding_rect::BoundingRect;
-use geo_types::{Rect, Point, Coordinate};
+use geo_types::{Coordinate, Point, Rect};
+use geos::from_geo::TryInto;
+use geos::GGeom;
 use mutable_slice::MutableSlice;
 use osm_boundaries_utils::build_boundary;
 use osmpbfreader::objects::{OsmId, OsmObj, Relation, Tags};
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use geos::from_geo::TryInto;
 
 type Coord = Point<f64>;
 
@@ -240,6 +240,50 @@ impl Zone {
             (&Some(ref mpoly1), &Some(ref mpoly2)) => {
                 let m_self: Result<GGeom, _> = mpoly1.try_into();
                 let m_other: Result<GGeom, _> = mpoly2.try_into();
+
+                match (&m_self, &m_other) {
+                    (&Ok(ref m_self), &Ok(ref m_other)) => {
+                        // In GEOS, "covers" is less strict than "contains".
+                        // eg: a polygon does NOT "contain" its boundary, but "covers" it.
+                        m_self.covers(&m_other)
+                        .map_err(|e| info!("impossible to compute geometies coverage for zone {:?}/{:?}: error {}",
+                        &self.osm_id, &other.osm_id, e))
+                        .unwrap_or(false)
+                    }
+                    (&Err(ref e), _) => {
+                        info!(
+                            "impossible to convert to geos for zone {:?}, error {}",
+                            &self.osm_id, e
+                        );
+                        debug!(
+                            "impossible to convert to geos the zone {:?}",
+                            serde_json::to_string(&self)
+                        );
+                        false
+                    }
+                    (_, &Err(ref e)) => {
+                        info!(
+                            "impossible to convert to geos for zone {:?}, error {}",
+                            &other.osm_id, e
+                        );
+                        debug!(
+                            "impossible to convert to geos the zone {:?}",
+                            serde_json::to_string(&other)
+                        );
+                        false
+                    }
+                }
+            }
+            _ => false,
+        }
+    }
+
+    // TODO factorize it with contains
+    pub fn contains_center(&self, other: &Zone) -> bool {
+        match (&self.boundary, &other.center) {
+            (&Some(ref mpoly1), &Some(ref point)) => {
+                let m_self: Result<GGeom, _> = mpoly1.try_into();
+                let m_other: Result<GGeom, _> = point.try_into();
 
                 match (&m_self, &m_other) {
                     (&Ok(ref m_self), &Ok(ref m_other)) => {

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -82,6 +82,8 @@ pub struct Zone {
     pub parent: Option<ZoneIndex>,
     pub wikidata: Option<String>,
     // pub links: Vec<ZoneIndex>
+    #[serde(default)]
+    pub approximative_boundaries: bool,
 }
 
 /// get all the international names from the osm tags
@@ -102,8 +104,7 @@ fn get_international_names(tags: &Tags, default_name: &str) -> BTreeMap<String, 
             let lang = LANG_NAME_REG.captures(k)?.get(1)?;
 
             Some((lang.as_str().into(), v.clone()))
-        })
-        .collect()
+        }).collect()
 }
 
 impl Zone {
@@ -125,6 +126,7 @@ impl Zone {
             center_tags: Tags::new(),
             wikidata: None,
             zip_codes: vec![],
+            approximative_boundaries: true,
         }
     }
 
@@ -140,39 +142,40 @@ impl Zone {
         self.parent = idx;
     }
 
-    pub fn from_osm(relation: &Relation, index: ZoneIndex) -> Option<Self> {
+    pub fn from_osm(tags: &Tags, index: ZoneIndex, osm_id: OsmId) -> Option<Self> {
         // Skip administrative region without name
-        let name = match relation.tags.get("name") {
+        let osm_id_str = match osm_id {
+            OsmId::Node(n) => format!("node:{}", n.0.to_string()),
+            OsmId::Relation(r) => format!("relation:{}", r.0.to_string()),
+            OsmId::Way(r) => format!("way:{}", r.0.to_string()),
+        };
+        let name = match tags.get("name") {
             Some(val) => val,
             None => {
                 debug!(
-                    "relation/{}: administrative region without name, skipped",
-                    relation.id.0
+                    "{}: administrative region without name, skipped",
+                    &osm_id_str
                 );
                 return None;
             }
         };
-        let level = relation
-            .tags
-            .get("admin_level")
-            .and_then(|s| s.parse().ok());
+        let level = tags.get("admin_level").and_then(|s| s.parse().ok());
 
-        let zip_code = relation
-            .tags
+        let zip_code = tags
             .get("addr:postcode")
-            .or_else(|| relation.tags.get("postal_code"))
+            .or_else(|| tags.get("postal_code"))
             .map_or("", |val| &val[..]);
         let zip_codes = zip_code
             .split(';')
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .sorted();
-        let wikidata = relation.tags.get("wikidata").map(|s| s.to_string());
+        let wikidata = tags.get("wikidata").map(|s| s.to_string());
 
-        let international_names = get_international_names(&relation.tags, name);
+        let international_names = get_international_names(&tags, name);
         Some(Self {
             id: index,
-            osm_id: format!("relation:{}", relation.id.0.to_string()), // for the moment we can only read relation
+            osm_id: osm_id_str,
             admin_level: level,
             zone_type: None,
             name: name.to_string(),
@@ -184,9 +187,10 @@ impl Zone {
             boundary: None,
             bbox: None,
             parent: None,
-            tags: relation.tags.clone(),
+            tags: tags.clone(),
             center_tags: Tags::new(),
             wikidata: wikidata,
+            approximative_boundaries: true,
         })
     }
 
@@ -196,9 +200,11 @@ impl Zone {
         index: ZoneIndex,
     ) -> Option<Self> {
         use geo::centroid::Centroid;
-        Self::from_osm(relation, index).map(|mut result| {
+        let osm_id = OsmId::Relation(relation.id);
+        Self::from_osm(&relation.tags, index, osm_id).map(|mut result| {
             result.boundary = build_boundary(relation, objects);
             result.bbox = result.boundary.as_ref().and_then(|b| b.bbox());
+            result.approximative_boundaries = false;
 
             let center = relation
                 .refs
@@ -321,8 +327,7 @@ impl Zone {
                     z.international_names.get(lang).unwrap_or(&z.name).clone()
                 });
                 (lang.to_string(), lbl)
-            })
-            .collect();
+            }).collect();
 
         self.international_labels = international_labels;
         self.label = label;
@@ -541,6 +546,7 @@ mod test {
             center_tags: Tags::new(),
             wikidata: None,
             zip_codes: zips.iter().map(|s| s.to_string()).collect(),
+            approximative_boundaries: false,
         }
     }
 
@@ -606,8 +612,7 @@ mod test {
             ("name:es", "bobito"),
             ("name", "bobito"),
             ("name:a_strange_lang_name", "bibi"),
-        ]
-        .into_iter()
+        ].into_iter()
         .map(|(k, v)| (k.into(), v.into()))
         .collect();
 

--- a/src/zone_tree.rs
+++ b/src/zone_tree.rs
@@ -1,0 +1,48 @@
+use gst::rtree::RTree;
+use std::iter::FromIterator;
+use utils::bbox_to_rect;
+use zone::{Zone, ZoneIndex};
+
+pub struct ZonesTree {
+    tree: RTree<ZoneIndex>,
+}
+
+impl Default for ZonesTree {
+    fn default() -> Self {
+        ZonesTree { tree: RTree::new() }
+    }
+}
+
+impl ZonesTree {
+    pub fn insert_zone(&mut self, z: &Zone) {
+        match z.bbox {
+            Some(ref b) => self.tree.insert(bbox_to_rect(b), z.id.clone()),
+            None => warn!("No bbox: Cannot insert zone with osm_id {}", z.osm_id),
+        }
+    }
+
+    pub fn fetch_zone_bbox(&self, z: &Zone) -> Vec<ZoneIndex> {
+        match z.bbox {
+            None => {
+                warn!("No bbox: Cannot fetch zone with osm_id {}", z.osm_id);
+                vec![]
+            }
+            Some(ref bbox) => self
+                .tree
+                .get(&bbox_to_rect(bbox))
+                .into_iter()
+                .map(|(_, z_idx)| z_idx.clone())
+                .collect(),
+        }
+    }
+}
+
+impl<'a> FromIterator<&'a Zone> for ZonesTree {
+    fn from_iter<I: IntoIterator<Item = &'a Zone>>(zones: I) -> Self {
+        let mut ztree = ZonesTree::default();
+        for z in zones {
+            ztree.insert_zone(z);
+        }
+        ztree
+    }
+}

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -96,8 +96,7 @@ impl ZoneTyper {
             .ok_or(ZoneTyperError::UnkownLevel(
                 zone.admin_level.clone(),
                 country_code.to_string(),
-            ))?
-            .clone())
+            ))?.clone())
     }
 
     pub fn contains_rule(&self, country_code: &str) -> bool {
@@ -187,8 +186,7 @@ where
                     &a_path.path(),
                     e
                 )
-            })
-            .ok()?;
+            }).ok()?;
         let country_code = a_path
             .path()
             .file_stem()
@@ -209,8 +207,7 @@ where
         .context(format!(
             "error while reading libpostal directory {:?}",
             yaml_files_folder
-        ))?
-        .filter_map(read_libpostal_file)
+        ))?.filter_map(read_libpostal_file)
         .collect())
 }
 
@@ -238,8 +235,7 @@ impl From<SerdeRulesOverrides> for RulesOverrides {
                 map.into_iter().map(move |(osm_id, rules)| {
                     (format!("{}:{}", osm_type.to_string(), osm_id), rules)
                 })
-            })
-            .collect();
+            }).collect();
         let i = serde
             .id_rules
             .into_iter()
@@ -247,8 +243,7 @@ impl From<SerdeRulesOverrides> for RulesOverrides {
                 map.into_iter().map(move |(osm_id, rules)| {
                     (format!("{}:{}", osm_type.to_string(), osm_id), rules)
                 })
-            })
-            .collect();
+            }).collect();
         RulesOverrides {
             contained_by: c,
             id_rules: i,

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -109,10 +109,10 @@ fn test_wrapper_for_lux_zones(a_cosmogony: &Cosmogony) {
         .unwrap();
 
     let bbox = zone.bbox.unwrap();
-    assert_relative_eq!(bbox.xmin, 5.9432118, epsilon = 1e-8);
-    assert_relative_eq!(bbox.ymin, 49.460907, epsilon = 1e-8);
-    assert_relative_eq!(bbox.xmax, 6.005144, epsilon = 1e-8);
-    assert_relative_eq!(bbox.ymax, 49.518616, epsilon = 1e-8);
+    assert_relative_eq!(bbox.min.x, 5.9432118, epsilon = 1e-8);
+    assert_relative_eq!(bbox.min.y, 49.460907, epsilon = 1e-8);
+    assert_relative_eq!(bbox.max.x, 6.005144, epsilon = 1e-8);
+    assert_relative_eq!(bbox.max.y, 49.518616, epsilon = 1e-8);
 }
 
 #[test]

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -61,8 +61,7 @@ fn create_cosmogony_for_lux() -> Cosmogony {
         true,
         "./libpostal/resources/boundaries/osm".into(),
         Some("lu".into()),
-    )
-    .expect("invalid cosmogony");
+    ).expect("invalid cosmogony");
     return cosmogony;
 }
 


### PR DESCRIPTION
[cosmogony.world](http://cosmogony.world/) still has a lot of missing cities. This is mainly due to the cities shape not being in osm.

But in osm, when cities are missing, there are often nodes with `type=city` or `type=town`.

In this PR we try to compute rough shape for those nodes.

In order to do this, we compute a [voronoi diagrams](https://en.wikipedia.org/wiki/Voronoi_diagram) for each "parent" zone.

the algorithm is roughly: 
for each parent:
 * take all nodes [`type=city` or `type=town`] in it and compute a voronoi from it
 * for each each take its voronoi and subtract:
   * the parent's shape
   * all nicely bounded cities in this parent.


This PR is a work in progress. There are still lots a TODOs and it depends on:
 * [x] https://github.com/georust/wkt/pull/38
 * [x] https://github.com/QwantResearch/osm_boundaries_utils_rs/pull/7
 * [x] https://github.com/georust/geos/pull/22

This should fix #19 