### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ matrix:
     - cargo test
     after_success:
     - |-
-      [ $TRAVIS_BRANCH = master ] &&
-      [ $TRAVIS_PULL_REQUEST = false ] &&
+      [ "$TRAVIS_TAG" = v$(cargo run -- --version | awk '{print $2}') ] &&
       cargo publish --token ${CRATESIO_TOKEN}
 env:
   global:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"


### PR DESCRIPTION
* Diff from 0.3.2: https://github.com/osm-without-borders/cosmogony/compare/4cf842a0f2b0ed6b66e308ee18a23319a3b6954e...amatissart:bump-version

* Update travis script to run `cargo publish` on the corresponding git tag