### PR TITLE
Fix i18n labels to match "name:*" tags only

### DIFF
--- a/src/zone.rs
+++ b/src/zone.rs
@@ -93,7 +93,7 @@ pub struct Zone {
 /// to reduce the size of the map
 fn get_international_names(tags: &Tags, default_name: &str) -> BTreeMap<String, String> {
     lazy_static! {
-        static ref LANG_NAME_REG: Regex = Regex::new("name:(.+)").unwrap();
+        static ref LANG_NAME_REG: Regex = Regex::new("^name:(.+)").unwrap();
     }
 
     tags.iter()

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -187,11 +187,11 @@ fn test_lux_zone_types() {
     assert!(!lux.tags.is_empty());
     assert_eq!(
         lux.international_labels.get("fr"),
-        Some(&"Luxembourg, Canton Luxembourg, Grand-duché de Luxembourg".to_string())
+        Some(&"Luxembourg, Canton Luxembourg, Luxembourg".to_string())
     );
     assert_eq!(
         lux.international_labels.get("de"),
-        Some(&"Luxemburg, Kanton Luxemburg, Großherzogtum Luxemburg".to_string())
+        Some(&"Luxemburg, Kanton Luxemburg, Luxemburg".to_string())
     );
 
     assert!(!lux.center_tags.is_empty());
@@ -216,10 +216,10 @@ fn test_lux_zone_types() {
     assert!(!lux.tags.is_empty());
     assert_eq!(
         lux.international_labels.get("fr"),
-        Some(&"Grand-duché de Luxembourg".to_string())
+        Some(&"Luxembourg".to_string())
     );
     assert_eq!(
         lux.international_labels.get("de"),
-        Some(&"Großherzogtum Luxemburg".to_string())
+        Some(&"Luxemburg".to_string())
     );
 }


### PR DESCRIPTION
The current regex matches all tags `*name:*` and keep the last one from the tags list for each language. As a consequence the i18n labels may actually contain the "official_name" (or potentially any other name).

I don't think that is expected. This PR updates the regex to match only tags **starting** with `name:`