### PR TITLE
Read extra names from "label" or "admin_center" nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: rust
 cache: cargo
 matrix:
   include:
-  - rust: nightly
-    before_script: rustup component add rustfmt-preview
-    script:  cargo fmt --all -- --check
   - rust: stable
+    before_script:
+    - rustup component add rustfmt
     script:
+    - cargo fmt --all -- --check
     - cargo test
     after_success:
     - |-

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ The libpostal types seem nice (and made by brighter people than us):
 - **country_region**: informal subdivision of a country without any political status
 - **country**: sovereign nations and their dependent territories, anything with an [ISO-3166 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
+### Names and Labels
+
+Cosmogony reads OSM tags to determine names and labels for all zones, in all available languages.
+
+In addition to `name:*` tags from boundary objects themselves, other names from [related objects](https://wiki.openstreetmap.org/wiki/Relation:boundary#Relation_members) are used
+as they may provide more languages : 
+ * nodes with role `label` (if present)
+ * nodes with role `admin_center` (if relevant: for cities, or on matching wikidata ID)
+
+> Note that these additional `name:*` values **are included in zone `tags`** in the output to help reusing, even if they are not part of the OSM object tags.
+
 ### Output schema
 
 Below is a brief example of the information contained in the cosmogony output.
@@ -109,7 +120,7 @@ Below is a brief example of the information contained in the cosmogony output.
 		"wikidata":"Q79669"}
 	],
 		"meta":{
-			"osm_filename":"alabama.osh.pbf",
+			"osm_filename":"alabama.osm.pbf",
 			"stats":{"level_counts":{"6":64,"8":272},
 			"zone_type_counts":{"City":272,"StateDistrict":64},
 			"wikidata_counts":{"6":58,"8":202},

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -27,7 +27,7 @@ pub struct CosmogonyStats {
 }
 
 impl CosmogonyStats {
-    pub fn compute(&mut self, zones: &Vec<Zone>) {
+    pub fn compute(&mut self, zones: &[Zone]) {
         for zone in zones {
             let type_ = zone
                 .zone_type
@@ -50,11 +50,11 @@ impl fmt::Display for CosmogonyStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (level, count) in &self.level_counts {
             let wd = self.wikidata_counts.get(level).unwrap_or(&0u64);
-            write!(f, "Admin level {}: {} element(s)\n", level, count)?;
-            write!(f, "    {} with wikidata id\n", wd)?;
+            writeln!(f, "Admin level {}: {} element(s)", level, count)?;
+            writeln!(f, "    {} with wikidata id", wd)?;
         }
         for (zone_type, count) in &self.zone_type_counts {
-            write!(f, "{:?}: {} element(s)\n", zone_type, count)?;
+            writeln!(f, "{:?}: {} element(s)", zone_type, count)?;
         }
 
         Ok(())

--- a/src/country_finder.rs
+++ b/src/country_finder.rs
@@ -40,7 +40,7 @@ impl CountryFinder {
                                 z.id.clone(),
                                 Country {
                                     iso: country_code.clone(),
-                                    admin_level: z.admin_level.clone(),
+                                    admin_level: z.admin_level,
                                 },
                             )
                         })
@@ -49,7 +49,7 @@ impl CountryFinder {
         }
     }
 
-    pub fn find_zone_country(&self, z: &Zone, inclusion: &Vec<ZoneIndex>) -> Option<String> {
+    pub fn find_zone_country(&self, z: &Zone, inclusion: &[ZoneIndex]) -> Option<String> {
         inclusion
             .iter()
             .chain(std::iter::once(&z.id)) // we also add the zone to check if it's itself a country

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -132,7 +132,7 @@ mod test {
         z
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn create_zones() -> Vec<Zone> {
         let l0 = LineString(vec![
             Point::new(0., 0.),     //  +------+

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -27,9 +27,9 @@ enum OsmPrimaryObjects {
 impl fmt::Display for OsmPrimaryObjects {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &OsmPrimaryObjects::Node => fmt.write_str("node")?,
-            &OsmPrimaryObjects::Way => fmt.write_str("way")?,
-            &OsmPrimaryObjects::Relation => fmt.write_str("relation")?,
+            OsmPrimaryObjects::Node => fmt.write_str("node")?,
+            OsmPrimaryObjects::Way => fmt.write_str("way")?,
+            OsmPrimaryObjects::Relation => fmt.write_str("relation")?,
         }
         Ok(())
     }
@@ -90,14 +90,12 @@ impl ZoneTyper {
         let country_rules = self
             .countries_rules
             .get(country_code)
-            .ok_or(ZoneTyperError::InvalidCountry(country_code.to_string()))?;
+            .ok_or_else(|| ZoneTyperError::InvalidCountry(country_code.to_string()))?;
         Ok(country_rules
             .get_zone_type(zone, zone_inclusions, all_zones)
-            .ok_or(ZoneTyperError::UnkownLevel(
-                zone.admin_level.clone(),
-                country_code.to_string(),
-            ))?
-            .clone())
+            .ok_or_else(|| {
+                ZoneTyperError::UnkownLevel(zone.admin_level.clone(), country_code.to_string())
+            })?)
     }
 
     pub fn contains_rule(&self, country_code: &str) -> bool {

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -194,6 +194,12 @@ fn test_lux_zone_types() {
         Some(&"Luxemburg, Kanton Luxemburg, Luxemburg".to_string())
     );
 
+    // Read names from center_tags
+    assert_eq!(
+        lux.international_labels.get("br"),
+        Some(&"Luksembourg, Canton Luxembourg, Luksembourg".to_string())
+    );
+
     assert!(!lux.center_tags.is_empty());
     assert_eq!(
         lux.center_tags.get("population"),
@@ -221,5 +227,11 @@ fn test_lux_zone_types() {
     assert_eq!(
         lux.international_labels.get("de"),
         Some(&"Luxemburg".to_string())
+    );
+
+    // Read names from label node
+    assert_eq!(
+        lux.international_labels.get("ak"),
+        Some(&"Laksembɛg".to_string())
     );
 }


### PR DESCRIPTION
* Complete tags with names from **"label"** node (if present) on all zones
* Complete tags with names from **"admin_center"** node (only for cities, or admin_center nodes with the same "wikidata" id as the relation.

Misc
 * Use stable "cargo fmt"
 * Minor changes, following clippy recommendations