### PR TITLE
 add new output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/src/cosmogony.rs
+++ b/src/cosmogony.rs
@@ -3,13 +3,13 @@ use std::fmt;
 use zone::Zone;
 extern crate serde;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Cosmogony {
     pub zones: Vec<Zone>,
     pub meta: CosmogonyMetadata,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CosmogonyMetadata {
     pub osm_filename: String,
     pub stats: CosmogonyStats,

--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -1,0 +1,40 @@
+use failure::Error;
+
+#[derive(PartialEq, Clone)]
+pub enum OutputFormat {
+    Json,
+    JsonGz,
+    JsonStream,
+    JsonStreamGz,
+}
+
+impl OutputFormat {
+    fn all_extensions() -> Vec<(String, OutputFormat)> {
+        vec![
+            (".json".into(), OutputFormat::Json),
+            (".jsonl".into(), OutputFormat::JsonStream),
+            (".json.gz".into(), OutputFormat::JsonGz),
+            (".jsonl.gz".into(), OutputFormat::JsonStreamGz),
+        ]
+    }
+
+    pub fn from_filename(filename: &str) -> Result<OutputFormat, Error> {
+        let extensions = OutputFormat::all_extensions();
+        extensions
+            .iter()
+            .find(|&&(ref e, _)| filename.ends_with(e))
+            .map(|&(_, ref f)| f.clone())
+            .ok_or_else(|| {
+                let extensions_str = extensions
+                    .into_iter()
+                    .map(|(e, _)| e)
+                    .collect::<Vec<String>>()
+                    .join(", ");
+                failure::err_msg(format!(
+                    "Unable to detect the file format from filename '{}'. \
+                     Accepted extensions are: {}",
+                    filename, extensions_str
+                ))
+            })
+    }
+}

--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -8,27 +8,24 @@ pub enum OutputFormat {
     JsonStreamGz,
 }
 
-impl OutputFormat {
-    fn all_extensions() -> Vec<(String, OutputFormat)> {
-        vec![
-            (".json".into(), OutputFormat::Json),
-            (".jsonl".into(), OutputFormat::JsonStream),
-            (".json.gz".into(), OutputFormat::JsonGz),
-            (".jsonl.gz".into(), OutputFormat::JsonStreamGz),
-        ]
-    }
+static ALL_EXTENTIONS: [(&str, OutputFormat); 4] = [
+    (".json", OutputFormat::Json),
+    (".jsonl", OutputFormat::JsonStream),
+    (".json.gz", OutputFormat::JsonGz),
+    (".jsonl.gz", OutputFormat::JsonStreamGz),
+];
 
+impl OutputFormat {
     pub fn from_filename(filename: &str) -> Result<OutputFormat, Error> {
-        let extensions = OutputFormat::all_extensions();
-        extensions
+        ALL_EXTENTIONS
             .iter()
             .find(|&&(ref e, _)| filename.ends_with(e))
             .map(|&(_, ref f)| f.clone())
             .ok_or_else(|| {
-                let extensions_str = extensions
+                let extensions_str = ALL_EXTENTIONS
                     .into_iter()
-                    .map(|(e, _)| e)
-                    .collect::<Vec<String>>()
+                    .map(|(e, _)| *e)
+                    .collect::<Vec<_>>()
                     .join(", ");
                 failure::err_msg(format!(
                     "Unable to detect the file format from filename '{}'. \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,13 @@ extern crate serde_yaml;
 extern crate structopt;
 #[macro_use]
 extern crate lazy_static;
+extern crate flate2;
 extern crate geos;
 extern crate rayon;
 
 pub mod cosmogony;
 mod country_finder;
+pub mod file_format;
 mod hierarchy_builder;
 mod mutable_slice;
 mod utils;
@@ -31,6 +33,7 @@ pub use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
 use country_finder::CountryFinder;
 use failure::Error;
 use failure::ResultExt;
+use file_format::OutputFormat;
 use hierarchy_builder::{build_hierarchy, find_inclusions};
 use mutable_slice::MutableSlice;
 use osmpbfreader::{OsmObj, OsmPbfReader};
@@ -261,4 +264,78 @@ pub fn build_cosmogony(
         },
     };
     Ok(cosmogony)
+}
+
+/// Stream Cosmogony's Zone from a Reader
+pub fn read_zones(
+    reader: impl std::io::BufRead,
+) -> impl std::iter::Iterator<Item = Result<Zone, Error>> {
+    reader
+        .lines()
+        .map(|l| l.map_err(|e| failure::err_msg(e.to_string())))
+        .map(|l| {
+            l.and_then(|l| serde_json::from_str(&l).map_err(|e| failure::err_msg(e.to_string())))
+        })
+}
+
+fn from_json_stream(reader: impl std::io::BufRead) -> Result<Cosmogony, Error> {
+    let zones = read_zones(reader).collect::<Result<_, _>>()?;
+
+    Ok(Cosmogony {
+        zones,
+        ..Default::default()
+    })
+}
+
+/// Load a cosmogony from a file
+pub fn load_cosmogony_from_file(input: &str) -> Result<Cosmogony, Error> {
+    let format = OutputFormat::from_filename(input)?;
+    let f = std::fs::File::open(&input)?;
+    let f = std::io::BufReader::new(f);
+    load_cosmogony(f, format)
+}
+
+/// Return an iterator on the zones
+/// if the input file is a jsonstream, the zones are streamed
+/// if the input file is a json, the whole cosmogony is loaded
+pub fn read_zones_from_file(
+    input: &str,
+) -> Result<Box<std::iter::Iterator<Item = Result<Zone, Error>>>, Error> {
+    let format = OutputFormat::from_filename(input)?;
+    let f = std::fs::File::open(&input)?;
+    let f = std::io::BufReader::new(f);
+    match format {
+        OutputFormat::JsonGz | OutputFormat::Json => {
+            let cosmo = load_cosmogony(f, format)?;
+            Ok(Box::new(cosmo.zones.into_iter().map(|z| Ok(z))))
+        }
+        OutputFormat::JsonStream => Ok(Box::new(read_zones(f))),
+        OutputFormat::JsonStreamGz => {
+            let r = flate2::bufread::GzDecoder::new(f);
+            let r = std::io::BufReader::new(r);
+            Ok(Box::new(read_zones(r)))
+        }
+    }
+}
+
+/// Load a cosmogony from a reader and a file_format
+pub fn load_cosmogony(
+    reader: impl std::io::BufRead,
+    format: OutputFormat,
+) -> Result<Cosmogony, Error> {
+    match format {
+        OutputFormat::JsonGz => {
+            let r = flate2::read::GzDecoder::new(reader);
+            serde_json::from_reader(r).map_err(|e| failure::err_msg(e.to_string()))
+        }
+        OutputFormat::Json => {
+            serde_json::from_reader(reader).map_err(|e| failure::err_msg(e.to_string()))
+        }
+        OutputFormat::JsonStream => from_json_stream(reader),
+        OutputFormat::JsonStreamGz => {
+            let r = flate2::bufread::GzDecoder::new(reader);
+            let r = std::io::BufReader::new(r);
+            from_json_stream(r)
+        }
+    }
 }

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -105,8 +105,8 @@ fn get_international_names(tags: &Tags, default_name: &str) -> BTreeMap<String, 
         .collect()
 }
 
-impl Zone {
-    pub fn default() -> Self {
+impl Default for Zone {
+    fn default() -> Self {
         Zone {
             id: ZoneIndex { index: 0 },
             osm_id: "".into(),
@@ -126,7 +126,9 @@ impl Zone {
             zip_codes: vec![],
         }
     }
+}
 
+impl Zone {
     pub fn is_admin(&self) -> bool {
         match self.zone_type {
             None => false,

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -29,6 +29,17 @@ fn test_cmd_with_json_output() {
 }
 
 #[test]
+fn test_cmd_with_json_stream_output() {
+    let output = launch_command_line(vec![
+        "-i",
+        "./tests/data/luxembourg_filtered.osm.pbf",
+        "-o",
+        concat!(env!("OUT_DIR"), "/test_cosmogony.jsonl"),
+    ]);
+    assert!(output.status.success());
+}
+
+#[test]
 fn test_cmd_with_json_gz_output() {
     let output = launch_command_line(vec![
         "-i",

--- a/tests/cosmogony_lux_test.rs
+++ b/tests/cosmogony_lux_test.rs
@@ -19,35 +19,63 @@ fn launch_command_line(args: Vec<&str>) -> Output {
 
 #[test]
 fn test_cmd_with_json_output() {
+    let out_file = concat!(env!("OUT_DIR"), "/test_cosmogony.json");
     let output = launch_command_line(vec![
         "-i",
         "./tests/data/luxembourg_filtered.osm.pbf",
         "-o",
-        concat!(env!("OUT_DIR"), "/test_cosmogony.json"),
+        out_file,
     ]);
     assert!(output.status.success());
+
+    let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
+    assert_eq!(cosmo.zones.len(), 195);
 }
 
 #[test]
 fn test_cmd_with_json_stream_output() {
+    let out_file = concat!(env!("OUT_DIR"), "/test_cosmogony.jsonl");
     let output = launch_command_line(vec![
         "-i",
         "./tests/data/luxembourg_filtered.osm.pbf",
         "-o",
-        concat!(env!("OUT_DIR"), "/test_cosmogony.jsonl"),
+        out_file,
     ]);
     assert!(output.status.success());
+
+    // we try also the streaming zone's reader
+    let zones: Vec<_> = cosmogony::read_zones_from_file(out_file).unwrap().collect();
+    assert_eq!(zones.len(), 195);
+}
+
+#[test]
+fn test_cmd_with_json_stream_gz_output() {
+    let out_file = concat!(env!("OUT_DIR"), "/test_cosmogony.jsonl.gz");
+    let output = launch_command_line(vec![
+        "-i",
+        "./tests/data/luxembourg_filtered.osm.pbf",
+        "-o",
+        out_file,
+    ]);
+    assert!(output.status.success());
+
+    // we try also the streaming zone's reader
+    let zones: Vec<_> = cosmogony::read_zones_from_file(out_file).unwrap().collect();
+    assert_eq!(zones.len(), 195);
 }
 
 #[test]
 fn test_cmd_with_json_gz_output() {
+    let out_file = concat!(env!("OUT_DIR"), "/test_cosmogony.json.gz");
     let output = launch_command_line(vec![
         "-i",
         "./tests/data/luxembourg_filtered.osm.pbf",
         "-o",
-        concat!(env!("OUT_DIR"), "/test_cosmogony.json.gz"),
+        out_file,
     ]);
     assert!(output.status.success());
+    let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
+    assert_eq!(cosmo.zones.len(), 195);
 }
 
 #[test]


### PR DESCRIPTION
add the possibility to dump json stream file

naming the ouput file "*.jsonl" (or ".jsonl.gz") will dump the cosmogony file as jsons stream, each line being a zone as json.

it makes it way ligher to read the file (it's not mandatory to load the whole file in memory).

For easier cosmogony use, several reading methods have been provided:

* `load_cosmogony_from_file` -> deduce the file format from extension and load the whole cosmogony
* `read_zones_from_file` -> decude the file format and return an iterator on the zones

* `read_zones`: stream zones from a buffered reader. Can be a bit more efficient if the cosmogony format is known.
