### PR TITLE
v0.7.1: update libpostal configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony_builder"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/cosmogony/Cargo.toml
+++ b/cosmogony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"


### PR DESCRIPTION
Update zones classification via libpostal:
 * Cities in Netherlands (https://github.com/osm-without-borders/libpostal/pull/11)
 * Cities in Portugal (https://github.com/osm-without-borders/libpostal/pull/12)