### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/cosmogony/src/file_format.rs
+++ b/cosmogony/src/file_format.rs
@@ -30,7 +30,7 @@ impl OutputFormat {
             .map(|&(_, ref f)| f.clone())
             .ok_or_else(|| {
                 let extensions_str = ALL_EXTENSIONS
-                    .into_iter()
+                    .iter()
                     .map(|(e, _)| *e)
                     .collect::<Vec<_>>()
                     .join(", ");


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.