### PR TITLE
Improvements about how tags from "label" and "center" nodes are used as fallback values

### DIFF
--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -144,7 +144,7 @@ impl ZoneExt for Zone {
         if let Some(node) = label_node {
             node.tags
                 .iter()
-                .filter(|(k, _)| k.starts_with("name:"))
+                .filter(|(k, _)| k.starts_with("name:") || *k == "population")
                 .for_each(|(k, v)| {
                     tags.entry(k.to_string()).or_insert(v.to_string());
                 })

--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -295,9 +295,14 @@ impl ZoneExt for Zone {
     }
 
     fn compute_names(&mut self) {
-        if self.zone_type == Some(ZoneType::City)
-            || self.wikidata.is_some()
-                && self.wikidata == self.center_tags.get("wikidata").map(|s| s.to_string())
+        let center_wikidata = self.center_tags.get("wikidata").map(|s| s.to_string());
+
+        // Names from the center node can be used as additional tags, with some precautions:
+        //  * for zones where the center node and and the relation itself represent the same wikidata entity
+        //  * for all cities where these entities are not explicitly distinct
+        if (self.wikidata.is_some() && self.wikidata == center_wikidata)
+            || (self.zone_type == Some(ZoneType::City)
+                && (center_wikidata.is_none() || self.wikidata.is_none()))
         {
             let center_names: Vec<_> = self
                 .center_tags

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -273,6 +273,9 @@ fn test_lux_zone_types() {
         lux.international_labels.get("ak"),
         Some(&"Laksembɛg".to_string())
     );
+
+    // Read population from label node
+    assert_eq!(lux.tags.get("population"), Some(&"493500".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
* **population**  
Administrative relations in OSM data often lack the `population` tag, whereas it's often present on _label_ nodes. This tag can notably be used as a weight value, and using the _label_ node is more reliable than the value that may be contained in the _admin_centre_ tags.   
This PR includes the `population` tag from the label node into the zone `tags`, using the existing behavior used for `name:*` tags.

* **names**
#72 implemented the import of name values from the _admin_centre_ tags for cities.  
In practice, this caused some rare issues for cities where the admin centre still represent a former administrative entity which is no longer considered as a city, for example after a merger of "communes" in France.  
This PR ignores names values from this _admin_centre_ node when both the node and the relation contain `wikidata` tags that do not match, as a hint that the names probably don't designate the same entities.
(See https://www.openstreetmap.org/relation/6838330 )