### PR TITLE
Upgrade docker image from Debian 9 (stretch) to 10 (buster)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 dist: bionic
 language: rust
 cache: cargo
+addons:
+  apt:
+    packages:
+    - libgeos-c1v5
+    - libgeos-dev
 matrix:
   include:
   - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: rust
 cache: cargo
 matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-slim-stretch as builder
+FROM rust:1-slim-buster as builder
 
 WORKDIR /srv/cosmogony
 
@@ -9,7 +9,7 @@ COPY . ./
 
 RUN cargo build --release
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 WORKDIR /srv
 


### PR DESCRIPTION
Debian 9 “Stretch” is now LTS: https://wiki.debian.org/LTS
And the [base docker images for Rust](https://hub.docker.com/_/rust) based on it are no longer updated with recent Rust versions.
