### PR TITLE
Replace precomputing of Geos geometries with shared cache, and upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -263,9 +263,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1488b04daa30b25f0beb19c2110fa507484ac8c2b8cad83d548cdda857f7f7a"
+checksum = "d893ed768bba4866e3e16b756c96ed7ef23ca270eac190000fc4e40c5d733467"
 dependencies = [
  "geo-types",
  "geographiclib-rs",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0e91cb835a9b740d38fc45efdf6392bedd20101f1e7419e464cd54f61373a1"
+checksum = "7583925a1fdb2b450c461fe0878ba6e99a8f1332b2bc72fb1383fd25b2f13bf2"
 dependencies = [
  "approx",
  "num-traits",
@@ -676,9 +676,9 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "osm_boundaries_utils"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2443c025634a217f155e1aba65931b7e2abac949333f633f2b23275535d0ce"
+checksum = "c2fd6aff2e6e543f245868de3caa9c5ef33db1d81b494de3323f7d82ff45f0fa"
 dependencies = [
  "geo",
  "geo-types",
@@ -770,24 +770,24 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.18.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
+checksum = "da78e04bc0e40f36df43ecc6575e4f4b180e8156c4efd73f13d5619479b05696"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.18.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e81f70c25aab9506f87253c55f7cdcd8917635d5597382958d20025c211bbbd"
+checksum = "49b2b929363268881afe6d24351e8b711ea5a1901a5e1549d3723ebcc5d3696d"
 dependencies = [
  "protobuf",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.18.0"
+version = "2.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af8d72d9e14fd41a954f4d5b310396151437c83d2bfcbf19d3073af90e46288"
+checksum = "02a4b843fcc85f42b9f717a34481b9a323527f1b6ac62b20776514c044fc7da9"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "smartstring"
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1084,9 +1084,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cosmogony = { path = "cosmogony" }
 log = "0.4"
 env_logger = "0.8"
-geo = "0.15"
+geo = "0.16"
 geo-types = { version = "0.6", features = ["rstar"] }
 geojson = { version = "0.20", features = ["geo-types"] }
 geos = { version = "7.0", features= ["geo"] }
@@ -24,7 +24,7 @@ serde_yaml = "0.8"
 itertools = "0.8"
 failure = "0.1"
 failure_derive = "0.1"
-osm_boundaries_utils = "0.8"
+osm_boundaries_utils = "0.8.2"
 regex = "1"
 flate2 = "1.0"
 rayon = "1.5"

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -135,7 +135,7 @@ fn get_parent<'a>(place: &Zone, zones: &'a [Zone], zones_rtree: &ZonesTree) -> O
         .fetch_zone_bbox(&place)
         .into_iter()
         .map(|z_idx| &zones[z_idx.index])
-        .filter(|z| z.contains_center(place) && z.zone_type.is_some())
+        .filter(|z| z.zone_type.is_some() && z.contains_center(place))
         .min_by_key(|z| z.zone_type)
 }
 

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -323,11 +323,11 @@ fn compute_voronoi(
 
         place.boundary = parent.boundary.clone();
         place.parent = Some(parent.id);
-        if let Some(ref boundary) = place.boundary {
-            place.bbox = boundary.bounding_rect();
-        }
         // If an error occurs, we can't just use the parent area so instead, we return nothing.
         if extrude_existing_town(&mut place, &towns, &geos_cache) {
+            if let Some(ref boundary) = place.boundary {
+                place.bbox = boundary.bounding_rect();
+            }
             return vec![place];
         }
         return Vec::new();
@@ -402,10 +402,10 @@ fn compute_voronoi(
                 Ok(s) => {
                     place.parent = Some(parent.id);
                     place.boundary = convert_to_geo(s);
+                    extrude_existing_town(&mut place, &towns, &geos_cache);
                     if let Some(ref boundary) = place.boundary {
                         place.bbox = boundary.bounding_rect();
                     }
-                    extrude_existing_town(&mut place, &towns, &geos_cache);
                     Some(place)
                 }
                 Err(e) => {


### PR DESCRIPTION
## Context
After Voronoi diagrams are built, the resulted boundaries need to be processed so that they don't overlap official boundaries defined in OSM. The current implementation of `additional_zones.rs` uses multiple `Vec` to store `Zone` and `Geometry` objects that are used to compute a geometry difference, using the Geos library.

## Bug
The implementation does not ensure that the map `z_idx_to_place_idx` used to make the link between these vectors contains correct indices. Zones for which the Geos conversion fails could cause a shift in this index.

This PR suggests to replace this mechanism with a new shared struct `GeosBoundaryCache` that is in charge of storing the Geos boundaries, indexed with explicit `ZoneIndex` values. It should be less error-prone, and possibly more performant as cities boundaries are converted to Geos objects only when necessary.
