### PR TITLE
German postcodes via geo search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "failure_derive",
  "flate2",
  "geo",
+ "geo-booleanop",
  "geo-types",
  "geojson",
  "geos",
@@ -319,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "futures"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,8 +381,20 @@ dependencies = [
  "geo-types",
  "geographiclib-rs",
  "num-traits",
- "robust",
+ "robust 0.2.2",
  "rstar",
+]
+
+[[package]]
+name = "geo-booleanop"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b68ff17c819296610e9eee41bdf5eb37f71b09870a95f0086e07d8fcc1f45b"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "num-traits",
+ "robust 0.1.2",
 ]
 
 [[package]]
@@ -871,6 +893,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "robust"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222155e5550abd9100afdcdefbd08aa1b856d226b60e327044ec21b1ece2f78e"
 
 [[package]]
 name = "robust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ flate2 = "1.0"
 rayon = "1.5"
 include_dir = "0.6"
 rstar = "0.8"
+geo-booleanop = "0.3.0"
 
 [dev-dependencies]
 approx = "0.3"

--- a/cosmogony/src/lib.rs
+++ b/cosmogony/src/lib.rs
@@ -3,7 +3,9 @@ mod model;
 pub mod mutable_slice;
 mod read;
 mod zone;
+mod postcode;
 
 pub use model::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
 pub use read::{load_cosmogony_from_file, read_zones_from_file};
 pub use zone::{Coord, Zone, ZoneIndex, ZoneType};
+pub use postcode::Postcode;

--- a/cosmogony/src/postcode.rs
+++ b/cosmogony/src/postcode.rs
@@ -16,6 +16,12 @@ pub struct Postcode {
     pub boundary: Option<geo_types::MultiPolygon<f64>>,
 }
 
+impl Postcode {
+    pub fn get_boundary(&self) -> Option<&geo_types::MultiPolygon<f64>> {
+        return self.boundary.as_ref()
+    }
+}
+
 impl Default for Postcode {
     fn default() -> Self {
         Postcode {
@@ -26,5 +32,4 @@ impl Default for Postcode {
     }
 }
 
-impl Postcode {
-}
+impl Postcode {}

--- a/cosmogony/src/postcode.rs
+++ b/cosmogony/src/postcode.rs
@@ -1,0 +1,30 @@
+use crate::mutable_slice::MutableSlice;
+use geo_types::{Coordinate, Geometry, MultiPolygon, Point, Rect};
+use log::warn;
+use osmpbfreader::objects::Tags;
+use serde::Serialize;
+use serde_derive::*;
+use std::collections::BTreeMap;
+use std::fmt;
+
+pub type Coord = Point<f64>;
+
+#[derive(Debug, Clone)]
+pub struct Postcode {
+    pub osm_id: String,
+    pub zipcode: String,
+    pub boundary: Option<geo_types::MultiPolygon<f64>>,
+}
+
+impl Default for Postcode {
+    fn default() -> Self {
+        Postcode {
+            osm_id: "".into(),
+            boundary: None,
+            zipcode: "".into(),
+        }
+    }
+}
+
+impl Postcode {
+}

--- a/cosmogony/src/postcode.rs
+++ b/cosmogony/src/postcode.rs
@@ -14,11 +14,16 @@ pub struct Postcode {
     pub osm_id: String,
     pub zipcode: String,
     pub boundary: geo_types::MultiPolygon<f64>,
+    pub area: f64
 }
 
 impl Postcode {
     pub fn get_boundary(&self) -> &geo_types::MultiPolygon<f64> {
         return &self.boundary
+    }
+
+    pub fn unsigned_area(&self) -> f64 {
+        return self.area;
     }
 }
 
@@ -28,6 +33,7 @@ impl Default for Postcode {
             osm_id: "".into(),
             boundary: MultiPolygon(vec![]),
             zipcode: "".into(),
+            area: 0.0
         }
     }
 }

--- a/cosmogony/src/postcode.rs
+++ b/cosmogony/src/postcode.rs
@@ -1,5 +1,5 @@
 use crate::mutable_slice::MutableSlice;
-use geo_types::{Coordinate, Geometry, MultiPolygon, Point, Rect};
+use geo_types::{Coordinate, Geometry, MultiPolygon, Point, Rect, Polygon};
 use log::warn;
 use osmpbfreader::objects::Tags;
 use serde::Serialize;
@@ -13,12 +13,12 @@ pub type Coord = Point<f64>;
 pub struct Postcode {
     pub osm_id: String,
     pub zipcode: String,
-    pub boundary: Option<geo_types::MultiPolygon<f64>>,
+    pub boundary: geo_types::MultiPolygon<f64>,
 }
 
 impl Postcode {
-    pub fn get_boundary(&self) -> Option<&geo_types::MultiPolygon<f64>> {
-        return self.boundary.as_ref()
+    pub fn get_boundary(&self) -> &geo_types::MultiPolygon<f64> {
+        return &self.boundary
     }
 }
 
@@ -26,7 +26,7 @@ impl Default for Postcode {
     fn default() -> Self {
         Postcode {
             osm_id: "".into(),
-            boundary: None,
+            boundary: MultiPolygon(vec![]),
             zipcode: "".into(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,11 @@ pub fn get_postcodes(
         if let OsmObj::Relation(ref relation) = *obj {
             if let Some(postcode) = Postcode::from_osm_relation(relation, pbf) {
                 // Ignore zone without boundary polygon for the moment
-                if postcode.boundary.is_some() {
-                    let bbox = postcode.boundary.as_ref().and_then(|b| b.bounding_rect()).unwrap();
-                    postcodes.push(PostcodeBbox::new(
-                        postcode,
-                        &bbox
-                    ));
-                }
+                let bbox = postcode.boundary.bounding_rect().unwrap();
+                postcodes.push(PostcodeBbox::new(
+                    postcode,
+                    &bbox
+                ));
             };
         }
     }

--- a/src/postcode_ext.rs
+++ b/src/postcode_ext.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 use rstar::{RTreeObject, AABB};
 use geo::{Point, Rect};
+use geo::algorithm::area::Area;
 
 
 #[derive(Debug)]
@@ -73,10 +74,14 @@ impl PostcodeExt for Postcode {
 
         let boundary = build_boundary(relation, objects);
 
-        boundary.map(|boundary| Postcode {
-            osm_id,
-            zipcode: zipcode.to_string(),
-            boundary,
+        boundary.map(|boundary| {
+            let area = boundary.unsigned_area();
+            Postcode {
+                osm_id,
+                zipcode: zipcode.to_string(),
+                boundary,
+                area
+            }
         })
     }
 }

--- a/src/postcode_ext.rs
+++ b/src/postcode_ext.rs
@@ -73,7 +73,7 @@ impl PostcodeExt for Postcode {
 
         let boundary = build_boundary(relation, objects);
 
-        Some(Postcode {
+        boundary.map(|boundary| Postcode {
             osm_id,
             zipcode: zipcode.to_string(),
             boundary,

--- a/src/postcode_ext.rs
+++ b/src/postcode_ext.rs
@@ -1,0 +1,82 @@
+// extends Zones to add some capabilities
+// The Zone's capabilities have been split in order to hide some functions specific to cosmogony
+// and that we do not want to expose in the model
+
+use cosmogony::{mutable_slice::MutableSlice, Coord, Zone, ZoneIndex, ZoneType, Postcode};
+use osm_boundaries_utils::build_boundary;
+use osmpbfreader::objects::{OsmId, OsmObj, Relation};
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::TryInto;
+use rstar::{RTreeObject, AABB};
+use geo::{Point, Rect};
+
+
+#[derive(Debug)]
+pub struct PostcodeBbox {
+    postcode: Postcode,
+    bbox: AABB<Point<f64>>,
+}
+
+impl PostcodeBbox {
+    pub fn new(postcode: Postcode, bbox: &Rect<f64>) -> Self {
+        PostcodeBbox {
+            postcode,
+            bbox: envelope(&bbox),
+        }
+    }
+
+    pub fn get_postcode(&self) -> &Postcode {
+        return &self.postcode;
+    }
+}
+
+
+impl RTreeObject for PostcodeBbox {
+    type Envelope = AABB<Point<f64>>;
+    fn envelope(&self) -> Self::Envelope {
+        self.bbox
+    }
+}
+
+
+fn envelope(bbox: &Rect<f64>) -> AABB<Point<f64>> {
+    AABB::from_corners(bbox.min().into(), bbox.max().into())
+}
+
+pub trait PostcodeExt {
+    /// create a zone from an osm relation and a geometry
+    fn from_osm_relation(
+        relation: &Relation,
+        objects: &BTreeMap<OsmId, OsmObj>,
+    ) -> Option<Postcode>;
+}
+
+impl PostcodeExt for Postcode {
+
+    fn from_osm_relation(
+        relation: &Relation,
+        objects: &BTreeMap<OsmId, OsmObj>,
+    ) -> Option<Self> {
+        // Skip postcode withjout postcode
+        let zipcode = match relation.tags.get("postal_code") {
+            Some(val) => val,
+            None => {
+                debug!(
+                    "relation/{}: postcode region without name, skipped",
+                    relation.id.0
+                );
+                ""
+            }
+        };
+
+        let osm_id = format!("relation:{}", relation.id.0.to_string());
+
+        let boundary = build_boundary(relation, objects);
+
+        Some(Postcode {
+            osm_id,
+            zipcode: zipcode.to_string(),
+            boundary,
+        })
+    }
+}

--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -151,25 +151,19 @@ impl ZoneExt for Zone {
         if let Some(boundary) = boundary.as_ref() {
             if let Some(bbox) = bbox {
                 if (zip_codes.is_empty()) {
-                    info!("ZipCodes were empty for {:?}, trying to fill them", name);
+                    //info!("ZipCodes were empty for {:?}, trying to fill them", name);
                     zip_codes = postcodes.locate_in_envelope_intersecting(&envelope(bbox))
-                        .filter(|postcode| {
-                            info!(" - Candidate Postcode: {:?}", postcode.get_postcode().zipcode);
+                        .filter(|postcode_bbox| {
+                            //info!(" - Candidate Postcode: {:?}", postcode_bbox.get_postcode().zipcode);
 
-                            let postcodeBoundary = postcode.get_postcode().get_boundary();
-                            if boundary.intersects(postcodeBoundary) {
-                                let x = BooleanOp::intersection(boundary, postcodeBoundary);
+                            let overlap_between_postcode_and_area = BooleanOp::intersection(boundary, postcode_bbox.get_postcode().get_boundary());
 
-                                // anteil überlappender Bereiches / Postcode: "Wieviel % des Postcodes sind von dieser Fläche befüllt"
-                                let percentage = x.unsigned_area() / postcodeBoundary.unsigned_area(); // TODO: cache postcodeBoundary size
+                            // anteil überlappender Bereiches / Postcode: "Wieviel % des Postcodes sind von dieser Fläche befüllt"
+                            let overlap_percentage_relative_to_postcode = overlap_between_postcode_and_area.unsigned_area() / postcode_bbox.get_postcode().unsigned_area();
 
-                                info!("   CHOSEN {} {:?}", percentage, percentage > 0.05);
-                                // at least 5% des Postcodes müssen in der genannten Fläche liegen
-                                percentage > 0.05
-                            } else {
-                                info!("   NOT CHOSEN");
-                                false
-                            }
+                            //info!("   CHOSEN {} {:?}", overlap_percentage_relative_to_postcode, overlap_percentage_relative_to_postcode > 0.05);
+                            // at least 5% des Postcodes müssen in der genannten Fläche liegen
+                            overlap_percentage_relative_to_postcode > 0.05
 
                         })
                         .map(|x| x.get_postcode().zipcode.to_string())


### PR DESCRIPTION
Hey everybody,

I've tried to include german Postcodes in the database, which means we cannot read the post_code attribute, but instead have to read an OSM boundary relation: https://wiki.openstreetmap.org/wiki/DE:Relation:boundary - so I've implemented a geo overlap search to determine the postcodes.

So far the code seems to work, but is quite ugly (I am just learning rust).

I want to polish this PR for a merge-able state, but I'd need your feedback on the following things:

- is the direction generally useful?
- any rust errors I should fix / improve upon?
- should we maybe make this configurable?

Thanks for your work,
Sebastian