### PR TITLE
Fix publish script and test --version command

### DIFF
--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -22,6 +22,16 @@ fn launch_command_line(args: Vec<&str>) -> Output {
 }
 
 #[test]
+fn test_cmd_version() {
+    let output = launch_command_line(vec!["--version"]);
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("cosmogony_builder {}\n", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
 fn test_cmd_with_json_output() {
     let out_file = concat!(env!("OUT_DIR"), "/test_cosmogony.json");
     let output = launch_command_line(vec![


### PR DESCRIPTION
In .travis.yml, `cargo run -- --version` is used to extract the current package version.  
But #106 introduced a small issue, that caused the `--version` command to be executed twice.

This PR should fix the issue, and adds a test to ensure the version is correctly returned.