### PR TITLE
Add and populate Zone.country_code field

### DIFF
--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -110,7 +110,7 @@ impl Default for Zone {
             wikidata: None,
             zip_codes: vec![],
             is_generated: true,
-            country_code: None
+            country_code: None,
         }
     }
 }

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -87,6 +87,7 @@ pub struct Zone {
     // pub links: Vec<ZoneIndex>
     #[serde(default)]
     pub is_generated: bool,
+    pub country_code: Option<String>,
 }
 
 impl Default for Zone {
@@ -109,6 +110,7 @@ impl Default for Zone {
             wikidata: None,
             zip_codes: vec![],
             is_generated: true,
+            country_code: None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,12 @@ fn type_zones(
                     z.zone_type = Some(t)
                 }
                 Some(Err(zone_typer::ZoneTyperError::InvalidCountry(c))) => {
+                    z.country_code = Some(c.clone());
                     info!("impossible to find rules for country {}", c);
                     *stats.zone_with_unkwown_country_rules.entry(c).or_insert(0) += 1;
                 }
                 Some(Err(zone_typer::ZoneTyperError::UnkownLevel(lvl, country))) => {
+                    z.country_code = Some(country.clone());
                     debug!(
                         "impossible to find a rule for level {:?} for country {}",
                         lvl, country

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ fn type_zones(
                 stats.zone_without_country += 1;
             }
             Some(Ok((country_code, t))) => {
-                z.country_code = Some(country_code.to_lowercase());
+                z.country_code = Some(country_code);
                 z.zone_type = Some(t)
             }
             Some(Err(zone_typer::ZoneTyperError::InvalidCountry(c))) => {

--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -94,6 +94,7 @@ impl ZoneExt for Zone {
             label: "".to_string(),
             zip_codes,
             is_generated: true,
+            country_code: None,
         })
     }
 
@@ -199,6 +200,7 @@ impl ZoneExt for Zone {
             center_tags,
             wikidata,
             is_generated: false,
+            country_code: None,
         })
     }
 
@@ -408,6 +410,7 @@ mod test {
             wikidata: None,
             zip_codes: zips.iter().map(|s| s.to_string()).collect(),
             is_generated: false,
+            country_code: None,
         }
     }
 

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -262,6 +262,7 @@ fn test_lux_zone_types() {
     assert_eq!(lux.osm_id, "relation:2171347");
     assert_eq!(lux.admin_level, Some(2));
     assert_eq!(lux.label, "Lëtzebuerg");
+    assert_eq!(lux.country_code, Some("LU".into()));
     assert!(lux.zip_codes.is_empty());
     assert!(lux.center.is_some());
     assert_eq!(&lux.parent, &None::<ZoneIndex>);

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -224,6 +224,7 @@ fn test_lux_zone_types() {
     assert_eq!(lux.osm_id, "relation:407489");
     assert_eq!(lux.admin_level, Some(8));
     assert_eq!(lux.label, "Luxembourg, Canton Luxembourg, Lëtzebuerg");
+    assert_eq!(lux.country_code, Some("lu".into()));
     assert!(lux.zip_codes.is_empty());
     assert!(lux.center.is_some());
     assert_eq!(

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -224,7 +224,7 @@ fn test_lux_zone_types() {
     assert_eq!(lux.osm_id, "relation:407489");
     assert_eq!(lux.admin_level, Some(8));
     assert_eq!(lux.label, "Luxembourg, Canton Luxembourg, Lëtzebuerg");
-    assert_eq!(lux.country_code, Some("lu".into()));
+    assert_eq!(lux.country_code, Some("LU".into()));
     assert!(lux.zip_codes.is_empty());
     assert!(lux.center.is_some());
     assert_eq!(


### PR DESCRIPTION
I'm trying to build region polygons for nearly all of the countries in the world, but I need separate per-country output (i.e. easily group all zones of a given country).

I was originally doing this by having a list of country codes and indexing into the [Geofabrik index](https://download.geofabrik.de/index-v1-nogeom.json) to obtain the specific country's PBF extract. However, some country codes are entirely missing from the Geofabrik index, such as `ae` which I believe is in the catch-all [GCC States](https://download.geofabrik.de/asia/gcc-states.html) extract.

That's something I can manually fix by adding my own index entries locally, but it makes me think that maybe I should just be running Cosmogony against the entire planet PBF. The only wrinkle in this is that in order to get per-country output, I would need to then analyze the output to construct the geographic hierarchy to know what zones belong to what countries. This is certainly doable, but seems like an unnecessary burden on the user of Cosmogony when Cosmogony seemingly already has this information.

This PR adds a new `country_code` field to the `Zone` struct.

I tested this on the aforementioned GCC States PBF extract and sure enough it populated the field as expected.