### PR TITLE
Bbox override

### DIFF
--- a/cosmogony/src/mutable_slice.rs
+++ b/cosmogony/src/mutable_slice.rs
@@ -1,4 +1,5 @@
 use crate::{Zone, ZoneIndex};
+use std::cmp::Ordering;
 
 // This struct is necessary to wrap the `zones` slice
 // and keep a mutable reference to a zone (and set
@@ -24,12 +25,11 @@ impl<'a> MutableSlice<'a> {
 
     pub fn get(&self, zindex: &ZoneIndex) -> &Zone {
         let idx = zindex.index;
-        if idx < self.idx {
-            &self.left[idx]
-        } else if idx == self.idx {
-            panic!("Cannot retrieve middle index");
-        } else {
-            &self.right[idx - self.idx - 1]
+
+        match idx.cmp(&self.idx) {
+            Ordering::Less => &self.left[idx],
+            Ordering::Greater => &self.right[idx - self.idx - 1],
+            Ordering::Equal => panic!("Cannot retrieve middle index"),
         }
     }
 }

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -117,11 +117,7 @@ impl Default for Zone {
 
 impl Zone {
     pub fn is_admin(&self) -> bool {
-        match self.zone_type {
-            None => false,
-            Some(ZoneType::NonAdministrative) => false,
-            _ => true,
-        }
+        !matches!(self.zone_type, None | Some(ZoneType::NonAdministrative))
     }
 
     pub fn set_parent(&mut self, idx: Option<ZoneIndex>) {

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -80,12 +80,8 @@ pub fn compute_additional_cities(
 
     let candidate_parent_zones = place_zones
         .par_iter()
-        .filter_map(|place| {
-            if place.zone_type.is_none() {
-                return None;
-            }
-            get_parent(&place, &zones, &zones_rtree).map(|p| (p, place))
-        })
+        .filter(|place| place.zone_type.is_some())
+        .filter_map(|place| get_parent(&place, &zones, &zones_rtree).map(|p| (p, place)))
         .filter(|(p, place)| {
             p.zone_type
                 .as_ref()

--- a/src/hierarchy_builder.rs
+++ b/src/hierarchy_builder.rs
@@ -136,7 +136,7 @@ mod test {
 
     fn zone_factory(idx: usize, ls: LineString<f64>, zone_type: Option<ZoneType>) -> Zone {
         let p = Polygon::new(ls, vec![]);
-        let mp = MultiPolygon(vec![p.clone()]);
+        let mp = MultiPolygon(vec![p]);
 
         let mut z = Zone::default();
         z.id.index = idx;
@@ -192,7 +192,7 @@ mod test {
     }
 
     fn assert_parent(zones: &[Zone], idx: usize, expected_parent: Option<usize>) {
-        match (expected_parent, zones[idx].parent.clone()) {
+        match (expected_parent, zones[idx].parent) {
             (None, None) => (),
             (Some(_), None) => panic!("Zone {} should have a parent", idx),
             (None, Some(_)) => panic!("Zone {} should not have a parent", idx),

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -33,7 +33,7 @@ impl CosmogonyMerger {
 
     fn read_cosmogony(
         &mut self,
-        file: &PathBuf,
+        file: &Path,
         writer: impl std::io::Write,
     ) -> Result<(), failure::Error> {
         let mut max_id = 0;


### PR DESCRIPTION
Allow to input a file with BBOX overrides. The syntax of this file would be as follows:

```json
{
    "osm:rel:2202162": [-5.54, 42.27, 8.56, 51.46],
    "osm:rel:1543125": [139.49, 35.41, 140.14, 35.89]
}
```