### PR TITLE
Ensure that the iterator returned by `read_zones_from_file` is Send + Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "failure",
  "flate2",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony_builder"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "approx 0.3.2",
  "cosmogony",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony_builder"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/cosmogony/Cargo.toml
+++ b/cosmogony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/cosmogony/src/read.rs
+++ b/cosmogony/src/read.rs
@@ -37,7 +37,7 @@ pub fn load_cosmogony_from_file(input: impl AsRef<Path>) -> Result<Cosmogony, Er
 /// if the input file is a json, the whole cosmogony is loaded
 pub fn read_zones_from_file(
     input: impl AsRef<Path>,
-) -> Result<Box<dyn std::iter::Iterator<Item = Result<Zone, Error>>>, Error> {
+) -> Result<Box<dyn std::iter::Iterator<Item = Result<Zone, Error>> + Sync + Send>, Error> {
     let format = OutputFormat::from_filename(input.as_ref())?;
     let f = std::fs::File::open(input.as_ref())?;
     let f = std::io::BufReader::new(f);


### PR DESCRIPTION
This will be useful for the ongoing integration of ES7 in "mimisrbrunn", that attempts to build a thread-safe `futures::stream::Stream`.