### PR TITLE
Build docker image in a github workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+
+env:
+  DOCKER_IMAGE_BASENAME: ghcr.io/osm-without-borders/cosmogony
+
+jobs:
+  build_docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Login to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get image name
+        run: |
+          VERSION=${GITHUB_REF#refs/*/}
+          if [ "$VERSION" == "master" ]; then
+            IMAGE_TAG=latest
+          else
+            IMAGE_TAG=$VERSION
+          fi
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE_BASENAME:$IMAGE_TAG" >> $GITHUB_ENV
+      - run: docker build --label "org.label-schema.vcs-ref=$GITHUB_SHA" -t $DOCKER_IMAGE .
+
+      - run: docker push $DOCKER_IMAGE


### PR DESCRIPTION
The docker image is pushed to Github Container Registry (https://ghcr.io).  

The login uses the `GITHUB_TOKEN` provided automatically during the workflow run.  
See https://docs.github.com/en/actions/reference/authentication-in-a-workflow for more details.