### PR TITLE
workflow: fix cargo publish

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -28,9 +28,10 @@ jobs:
 
       - name: Publish crate
         if: startsWith(github.ref, 'refs/tags/')
-        working-directory: ./cosmogony
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          [ "$TAG" = v$(cargo run -- --version | awk '{print $2}') ] && cargo publish
+          [ "$TAG" = v$(cargo run -- --version | awk '{print $2}') ] \
+            && cd cosmogony \
+            && cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATESIO_TOKEN }}


### PR DESCRIPTION
`cargo run -- --version` needs to be executed in the root folder :sweat_smile: 