### PR TITLE
Update outdated depedencies :latin_cross: 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "cosmogony_builder"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "approx 0.5.0",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "flat_map"
-version = "0.0.9"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbb562ef75bc322a6d4b5860794457438b89079f23471fb2ba876c2f39b24e5"
+checksum = "e4fa2a56a33c493fc81acbad4676c599cf2b128f21462a020043ea1eee46244f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "osm_boundaries_utils"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae39916a4d4ef0609d0be56d6bf6800b6fa57d4469959fd4af3ca0dafffbedb0"
+checksum = "dd6c56628b8a1a8fc78615358e83c5f87d04e46229e9587232ad793117ed79ff"
 dependencies = [
  "geo",
  "geo-types",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "osmpbfreader"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35ee93f436bd4685458c4f27df8071f7ff10ee4f9fadf1d4cfd14a940bc5672"
+checksum = "350c902b84c57c1d0fa657bfbf380cb1cdcc7352732aa8763ec4bbed4a474a8b"
 dependencies = [
  "byteorder",
  "flat_map",
@@ -641,9 +641,8 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "pub-iterator-type",
- "rental",
+ "self_cell",
  "serde",
- "serde_derive",
  "smartstring",
 ]
 
@@ -787,27 +786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "rental"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc89fe2acac36d212474d138aaf939c04a82df5b61d07011571ebce5aef81f2e"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "robust"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,10 +816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "self_cell"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
+
+[[package]]
 name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,18 +34,18 @@ checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "approx"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "approx"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
 dependencies = [
  "num-traits",
 ]
@@ -138,7 +138,7 @@ name = "cosmogony_builder"
 version = "0.10.3"
 dependencies = [
  "anyhow",
- "approx 0.3.2",
+ "approx 0.5.0",
  "cosmogony",
  "env_logger",
  "flate2",
@@ -235,9 +235,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -384,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "hash32"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,26 +436,21 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "include_dir"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b56e147e6187d61e9d0f039f10e070d0c0a887e24fe0bb9ca3f29bfde62cab"
+checksum = "7fe7734d776eb702d33f1b68730696db57c87facfd526d2044a308a0c8466318"
 dependencies = [
- "glob",
- "include_dir_impl",
- "proc-macro-hack",
+ "include_dir_macros",
 ]
 
 [[package]]
-name = "include_dir_impl"
-version = "0.6.2"
+name = "include_dir_macros"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
+checksum = "253ba5156abc78673208f900dd686e1e000e6edc5633231d309acded2b66026d"
 dependencies = [
- "anyhow",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
 ]
 
 [[package]]
@@ -476,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -705,12 +694,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,18 +19,18 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "approx"
@@ -81,9 +81,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "byteorder"
@@ -105,9 +105,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
 dependencies = [
  "cfg-if",
 ]
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "geos"
-version = "8.0.1"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4141ef0f5c9e8c64cc965c5122b23909a095da3434eeef3367f78b4a7acc7851"
+checksum = "86ea2ad94ad979a2aaf3d15c9a1cd21d798f3de6eb813032af0f144984c5f64b"
 dependencies = [
  "c_vec",
  "doc-comment",
@@ -397,6 +397,12 @@ checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
@@ -436,9 +442,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "include_dir"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a924bd335356c7622dff9ee33d06920afcf7f762a1a991236645e08c8a484b"
+checksum = "24b56e147e6187d61e9d0f039f10e070d0c0a887e24fe0bb9ca3f29bfde62cab"
 dependencies = [
  "glob",
  "include_dir_impl",
@@ -447,15 +453,25 @@ dependencies = [
 
 [[package]]
 name = "include_dir_impl"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afae3917f781921d7c7813992ccadff7e816f7e6ecb4b70a9ec3e740d51da3d6"
+checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -469,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -481,9 +497,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "linked-hash-map"
@@ -502,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -541,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -625,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "osmpbfreader"
-version = "0.14.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea16406551d540a9c80eff0c2886f88ce0bb8160349bb8904208365bf4c7ac4"
+checksum = "c35ee93f436bd4685458c4f27df8071f7ff10ee4f9fadf1d4cfd14a940bc5672"
 dependencies = [
  "byteorder",
  "flat_map",
@@ -636,7 +652,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "pub-iterator-type",
- "self_cell",
+ "rental",
  "serde",
  "serde_derive",
  "smartstring",
@@ -662,9 +678,9 @@ checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "proc-macro-error"
@@ -698,33 +714,33 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.24.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.24.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09321cef9bee9ddd36884f97b7f7cc92a586cdc74205c4b3aeba65b5fc9c6f90"
+checksum = "3df8c98c08bd4d6653c2dbae00bd68c1d1d82a360265a5b0bbc73d48c63cb853"
 dependencies = [
  "protobuf",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.24.1"
+version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afb68a6d768571da3db86ce55f0f62966e0fc25eaf96acd070ea548a91b0d23"
+checksum = "394a73e2a819405364df8d30042c0f1174737a763e0170497ec9d36f8a2ea8f7"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -738,9 +754,9 @@ checksum = "858afdbecdce657c6e32031348cf7326da7700c869c368a136d31565972f7018"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -788,6 +804,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rental"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc89fe2acac36d212474d138aaf939c04a82df5b61d07011571ebce5aef81f2e"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "robust"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,9 +832,9 @@ checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 
 [[package]]
 name = "rstar"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d743ebe516592df4dd542dfe823577b811299f7bee1106feb1bbb993dbac"
+checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
 dependencies = [
  "heapless",
  "num-traits",
@@ -807,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
 name = "scopeguard"
@@ -818,22 +855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "self_cell"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c924e8e521faa453317ab6887122657f1855e9c46f0fb5e6b4bdc3be845353"
-
-[[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -842,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -853,27 +884,27 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
 dependencies = [
  "dtoa",
- "linked-hash-map",
+ "indexmap",
  "serde",
  "yaml-rust",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smartstring"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29620fe111ceaba7a50fd806b5f44c1ef44a697a739f6677a4464c7ea8685997"
+checksum = "31aa6a31c0c2b21327ce875f7e8952322acfcfd0c27569a6e18a647281352c9b"
 dependencies = [
  "serde",
  "static_assertions",
@@ -899,9 +930,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -910,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -923,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -952,18 +983,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-segmentation"
@@ -984,9 +1015,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,21 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backtrace"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,12 +96,6 @@ name = "c_vec"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd7a427adc0135366d99db65b36dae9237130997e560ed61118041fb72be6e8"
-
-[[package]]
-name = "cc"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -152,7 +122,7 @@ dependencies = [
 name = "cosmogony"
 version = "0.10.3"
 dependencies = [
- "failure",
+ "anyhow",
  "flate2",
  "geo-types",
  "geojson",
@@ -167,11 +137,10 @@ dependencies = [
 name = "cosmogony_builder"
 version = "0.10.3"
 dependencies = [
+ "anyhow",
  "approx 0.3.2",
  "cosmogony",
  "env_logger",
- "failure",
- "failure_derive",
  "flate2",
  "geo",
  "geo-types",
@@ -275,28 +244,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -435,12 +382,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "glob"
@@ -671,15 +612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "osm_boundaries_utils"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,12 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,18 +929,6 @@ checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 cosmogony = { path = "cosmogony" }
-env_logger = "0.8"
+env_logger = "0.9"
 flate2 = "1.0"
 geo = "0.18"
 geojson = { version = "0.22", features = ["geo-types"] }
 geos = { version = "8.0", features= ["geo"] }
 geo-types = { version = "0.7", features = ["rstar"] }
-include_dir = "0.6"
-itertools = "0.9"
+include_dir = "0.7"
+itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 osm_boundaries_utils = "0.9"
@@ -26,9 +26,9 @@ regex = "1"
 rstar = "0.8"
 serde_derive = "1"
 serde_json = "1"
-serde = {version = "1", features = ["rc"]}
+serde = { version = "1", features = ["rc"] }
 serde_yaml = "0.8"
 structopt = "0.3"
 
 [dev-dependencies]
-approx = "0.3"
+approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony_builder"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"
@@ -19,8 +19,8 @@ include_dir = "0.7"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-osm_boundaries_utils = "0.9"
-osmpbfreader = "0.14"
+osm_boundaries_utils = "0.10"
+osmpbfreader = "0.15"
 rayon = "1.5"
 regex = "1"
 rstar = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.11.0"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,29 +7,28 @@ repository = "https://github.com/osm-without-borders/cosmogony"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 cosmogony = { path = "cosmogony" }
-log = "0.4"
 env_logger = "0.8"
+flate2 = "1.0"
 geo = "0.18"
-geo-types = { version = "0.7", features = ["rstar"] }
 geojson = { version = "0.22", features = ["geo-types"] }
 geos = { version = "8.0", features= ["geo"] }
-structopt = "0.3"
-osmpbfreader = "0.14"
+geo-types = { version = "0.7", features = ["rstar"] }
+include_dir = "0.6"
+itertools = "0.9"
 lazy_static = "1"
-serde = {version = "1", features = ["rc"]}
+log = "0.4"
+osm_boundaries_utils = "0.9"
+osmpbfreader = "0.14"
+rayon = "1.5"
+regex = "1"
+rstar = "0.8"
 serde_derive = "1"
 serde_json = "1"
+serde = {version = "1", features = ["rc"]}
 serde_yaml = "0.8"
-itertools = "0.9"
-failure = "0.1"
-failure_derive = "0.1"
-osm_boundaries_utils = "0.9"
-regex = "1"
-flate2 = "1.0"
-rayon = "1.5"
-include_dir = "0.6"
-rstar = "0.8"
+structopt = "0.3"
 
 [dev-dependencies]
 approx = "0.3"

--- a/cosmogony/Cargo.toml
+++ b/cosmogony/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["osm", "boundary", "geography"]
 categories = ["science", "algorithms"]
 description = "Provides geographical zones with a structured hierarchy"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/cosmogony/Cargo.toml
+++ b/cosmogony/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"
@@ -17,7 +17,7 @@ flate2 = "1.0"
 geojson = { version = "0.22", features = ["geo-types"] }
 geo-types = { version = "0.7", features = ["use-rstar"] }
 log = "0.4"
-osmpbfreader = "0.14"
+osmpbfreader = "0.15"
 serde_derive = "1"
 serde_json = "1"
 serde = {version = "1", features = ["rc"]}

--- a/cosmogony/Cargo.toml
+++ b/cosmogony/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-log = "0.4"
-geo-types = { version = "0.7", features = ["use-rstar"] }
+anyhow = "1.0"
+flate2 = "1.0"
 geojson = { version = "0.22", features = ["geo-types"] }
-serde = {version = "1", features = ["rc"]}
+geo-types = { version = "0.7", features = ["use-rstar"] }
+log = "0.4"
+osmpbfreader = "0.14"
 serde_derive = "1"
 serde_json = "1"
-failure = "0.1"
-flate2 = "1.0"
-osmpbfreader = "0.14"
+serde = {version = "1", features = ["rc"]}

--- a/cosmogony/src/file_format.rs
+++ b/cosmogony/src/file_format.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::{anyhow, Error};
 use std::path::Path;
 
 #[derive(PartialEq, Clone)]
@@ -34,12 +34,12 @@ impl OutputFormat {
                     .map(|(e, _)| *e)
                     .collect::<Vec<_>>()
                     .join(", ");
-                failure::err_msg(format!(
+                anyhow!(
                     "Unable to detect the file format from filename '{}'. \
                      Accepted extensions are: {}",
                     filename.as_ref().display(),
                     extensions_str
-                ))
+                )
             })
     }
 }

--- a/cosmogony/src/read.rs
+++ b/cosmogony/src/read.rs
@@ -35,7 +35,7 @@ pub fn load_cosmogony_from_file(input: impl AsRef<Path>) -> Result<Cosmogony, Er
 /// if the input file is a json, the whole cosmogony is loaded
 pub fn read_zones_from_file(
     input: impl AsRef<Path>,
-) -> Result<Box<dyn std::iter::Iterator<Item = Result<Zone, Error>> + Sync + Send>, Error> {
+) -> Result<Box<dyn Iterator<Item = Result<Zone, Error>> + Send + Sync>, Error> {
     let format = OutputFormat::from_filename(input.as_ref())?;
     let f = std::fs::File::open(input.as_ref())?;
     let f = std::io::BufReader::new(f);

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -187,7 +187,6 @@ where
     D: serde::Deserializer<'de>,
 {
     use serde::Deserialize;
-    use std::convert::TryInto;
 
     Option::<geojson::GeoJson>::deserialize(d).map(|option| {
         option.and_then(|geojson| match geojson {

--- a/src/country_finder.rs
+++ b/src/country_finder.rs
@@ -50,7 +50,7 @@ impl CountryFinder {
         inclusion
             .iter()
             .chain(std::iter::once(&z.id)) // we also add the zone to check if it's itself a country
-            .filter_map(|parent_index| self.countries.get(&parent_index))
+            .filter_map(|parent_index| self.countries.get(parent_index))
             .max_by_key(|c| c.admin_level.unwrap_or(0u32))
             .map(|c| c.iso.clone())
     }

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use cosmogony::{file_format::OutputFormat, read_zones_from_file, Zone, ZoneIndex};
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -11,7 +12,7 @@ struct CosmogonyMerger {
 fn to_json_stream(
     mut writer: impl std::io::Write,
     zones: impl std::iter::Iterator<Item = Zone>,
-) -> Result<(), failure::Error> {
+) -> Result<()> {
     for z in zones {
         serde_json::to_writer(&mut writer, &z)?;
         writer.write_all(b"\n")?;
@@ -24,18 +25,14 @@ impl CosmogonyMerger {
         &mut self,
         files: &[PathBuf],
         mut writer: impl std::io::Write,
-    ) -> Result<(), failure::Error> {
+    ) -> Result<()> {
         for f in files {
-            self.read_cosmogony(&f, &mut writer)?;
+            self.read_cosmogony(f, &mut writer)?;
         }
         Ok(())
     }
 
-    fn read_cosmogony(
-        &mut self,
-        file: &PathBuf,
-        writer: impl std::io::Write,
-    ) -> Result<(), failure::Error> {
+    fn read_cosmogony(&mut self, file: &Path, writer: impl std::io::Write) -> Result<()> {
         let mut max_id = 0;
         let zones = read_zones_from_file(file)?
             .into_iter()
@@ -59,7 +56,7 @@ impl CosmogonyMerger {
     }
 }
 
-pub fn merge_cosmogony(files: &[PathBuf], output: &Path) -> Result<(), failure::Error> {
+pub fn merge_cosmogony(files: &[PathBuf], output: &Path) -> Result<()> {
     let mut merger = CosmogonyMerger::default();
 
     let format = OutputFormat::from_filename(output)?;

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -1,7 +1,5 @@
-use cosmogony::{Zone, ZoneIndex, ZoneType};
-/* use failure::Fail; */
-/* use failure::{err_msg, Error}; */
 use anyhow::{anyhow, Error};
+use cosmogony::{Zone, ZoneIndex, ZoneType};
 use log::warn;
 use serde_derive::*;
 use std::collections::BTreeMap;

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -1,6 +1,7 @@
 use cosmogony::{Zone, ZoneIndex, ZoneType};
-use failure::Fail;
-use failure::{err_msg, Error};
+/* use failure::Fail; */
+/* use failure::{err_msg, Error}; */
+use anyhow::{anyhow, Error};
 use log::warn;
 use serde_derive::*;
 use std::collections::BTreeMap;
@@ -58,11 +59,8 @@ struct CountryAdminTypeRules {
     // we don't implement libpostal's 'use_admin_center' as we don't need it
 }
 
-#[derive(Debug, Fail)]
 pub enum ZoneTyperError {
-    #[fail(display = "impossible to find country {}", _0)]
     InvalidCountry(String),
-    #[fail(display = "no lvl {:?} in libpostal rule for {}", _0, _1)]
     UnkownLevel(Option<u32>, String),
 }
 
@@ -72,10 +70,10 @@ impl ZoneTyper {
             countries_rules: read_libpostal_yaml_folder()?,
         };
         if z.countries_rules.is_empty() {
-            Err(err_msg(format!(
+            Err(anyhow!(
                 "no country rules have been loaded, the libpostal directory \
                  must contains valid libpostal rules"
-            )))
+            ))
         } else {
             Ok(z)
         }
@@ -92,11 +90,9 @@ impl ZoneTyper {
             .countries_rules
             .get(country_code)
             .ok_or_else(|| ZoneTyperError::InvalidCountry(country_code.to_string()))?;
-        Ok(country_rules
+        country_rules
             .get_zone_type(zone, zone_inclusions, all_zones)
-            .ok_or_else(|| {
-                ZoneTyperError::UnkownLevel(zone.admin_level, country_code.to_string())
-            })?)
+            .ok_or_else(|| ZoneTyperError::UnkownLevel(zone.admin_level, country_code.to_string()))
     }
 
     pub fn contains_rule(&self, country_code: &str) -> bool {
@@ -149,14 +145,13 @@ impl RulesOverrides {
                 if self.contained_by.is_empty() {
                     return None;
                 }
-                let parents_osm_id = zone_inclusions
+                let mut parents_osm_id = zone_inclusions
                     .iter()
                     .map(|idx| &all_zones[idx.index].osm_id);
 
                 parents_osm_id
-                    .filter_map(|parent_osm_id| self.contained_by.get(parent_osm_id))
-                    .next()
-                    .and_then(|ref country_rules| {
+                    .find_map(|parent_osm_id| self.contained_by.get(parent_osm_id))
+                    .and_then(|country_rules| {
                         country_rules
                             .get_zone_type(zone, zone_inclusions, all_zones)
                             .map(Some)
@@ -169,7 +164,7 @@ impl RulesOverrides {
 fn read_libpostal_yaml_folder() -> Result<BTreeMap<String, CountryAdminTypeRules>, Error> {
     Ok(LIBPOSTAL_RULES_DIR.files().iter().filter_map(|d| {
         let contents = d.contents_utf8()?;
-        let deserialized_level = read_libpostal_yaml(&contents)
+        let deserialized_level = read_libpostal_yaml(contents)
             .map_err(|e| {
                 warn!(
                     "Levels corresponding to file: {:?} have been skipped due to {}",
@@ -196,7 +191,7 @@ fn read_libpostal_yaml_folder() -> Result<BTreeMap<String, CountryAdminTypeRules
 }
 
 fn read_libpostal_yaml(contents: &str) -> Result<CountryAdminTypeRules, Error> {
-    Ok(serde_yaml::from_str(&contents)?)
+    Ok(serde_yaml::from_str(contents)?)
 }
 
 // stuff used for serde
@@ -261,7 +256,7 @@ mod test {
         "5": "city_district"
         "8": "city""#;
 
-        let deserialized_levels = read_libpostal_yaml(&yaml_basic).expect("invalid yaml");
+        let deserialized_levels = read_libpostal_yaml(yaml_basic).expect("invalid yaml");
 
         assert_eq!(
             deserialized_levels
@@ -297,9 +292,9 @@ mod test {
                         admin_level:
                             "10": "suburb""#;
 
-        let deserialized_levels = read_libpostal_yaml(&yaml_ko);
+        let deserialized_levels = read_libpostal_yaml(yaml_ko);
 
-        assert_eq!(deserialized_levels.is_err(), true);
+        assert!(deserialized_levels.is_err());
     }
 
     #[test]
@@ -320,7 +315,7 @@ mod test {
                 "407489":
                     admin_level:
                         "9": "city_district""#;
-        let deserialized_levels = read_libpostal_yaml(&yaml).expect("invalid yaml");
+        let deserialized_levels = read_libpostal_yaml(yaml).expect("invalid yaml");
 
         assert_eq!(
             deserialized_levels
@@ -360,7 +355,7 @@ mod test {
                 "1803923": "city_district"
                 "42": null # it is a way in libpostal to remove a zone from being typed
                 "#;
-        let deserialized_levels = read_libpostal_yaml(&yaml).expect("invalid yaml");
+        let deserialized_levels = read_libpostal_yaml(yaml).expect("invalid yaml");
 
         assert_eq!(
             deserialized_levels
@@ -424,7 +419,7 @@ mod test {
                     admin_level:
                         "9": "suburb"
                 "#;
-        read_libpostal_yaml(&yaml).expect("invalid yaml")
+        read_libpostal_yaml(yaml).expect("invalid yaml")
     }
 
     #[test]
@@ -433,11 +428,13 @@ mod test {
 
         let mut idx = 0usize;
         let mut make_zone = |id: &str, lvl| {
-            let mut z = Zone::default();
-            z.id = ZoneIndex { index: idx };
+            let z = Zone {
+                id: ZoneIndex { index: idx },
+                osm_id: format!("relation:{}", id.to_string()),
+                admin_level: lvl,
+                ..Default::default()
+            };
             idx += 1;
-            z.osm_id = format!("relation:{}", id.to_string());
-            z.admin_level = lvl;
             z
         };
         let zones = vec![
@@ -460,7 +457,6 @@ mod test {
                         .find(|z| z.osm_id == format!("relation:{}", osm_id))
                         .unwrap()
                         .id
-                        .clone()
                 };
                 inclusions[find_zone_id(z_osm_id).index] =
                     parents_id.into_iter().map(&find_zone_id).collect();
@@ -480,7 +476,7 @@ mod test {
                 .iter()
                 .find(|z| z.osm_id == format!("relation:{}", osm_id))
                 .unwrap();
-            rules.get_zone_type(&z, &inclusions[z.id.index], &zones)
+            rules.get_zone_type(z, &inclusions[z.id.index], &zones)
         };
 
         // even if z1 has no admin_level it has explicitly been set by libpostal to city_district

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -162,7 +162,7 @@ impl RulesOverrides {
 }
 
 fn read_libpostal_yaml_folder() -> Result<BTreeMap<String, CountryAdminTypeRules>, Error> {
-    Ok(LIBPOSTAL_RULES_DIR.files().iter().filter_map(|d| {
+    Ok(LIBPOSTAL_RULES_DIR.files().filter_map(|d| {
         let contents = d.contents_utf8()?;
         let deserialized_level = read_libpostal_yaml(contents)
             .map_err(|e| {


### PR DESCRIPTION
As a contribution of sanitizing dependencies in mimir's ecosystem:

 - replace unmaintained `failure` crate with `anyhow` (they basically do the same job of "I don't want any fined-grained error management)
 - cargo update and manually update outdated pinned dependancies
 - update to Rust 2021 & fix clippy lints