### PR TITLE
add production profile with aggressive link time optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,8 @@ structopt = "0.3"
 
 [dev-dependencies]
 approx = "0.5"
+
+[profile.production]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /srv
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y libgeos-c1v5 libgeos-dev && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=builder /srv/cosmogony/target/release/cosmogony /usr/bin/cosmogony
+COPY --from=builder /srv/cosmogony/target/production/cosmogony /usr/bin/cosmogony
 
 ENTRYPOINT ["cosmogony"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y libgeos-c1v5 libgeos-dev && apt-get cle
 
 COPY . ./
 
-RUN cargo build --release
+RUN cargo build --profile production
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
The new [1.57](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html) version of Rust allows to create profiles different than `debug` and `release`.

As cosmogony is very heavy on CPU I think we should enable aggressive compile-time optimizations, and this new cargo feature allows to do it at basically no cost.

We will have to wait until the docker images for x86_64 are updated before we merge this though :grimacing: 