### PR TITLE
Use clap instead of structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,17 +96,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -139,6 +145,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "approx 0.5.0",
+ "clap",
  "cosmogony",
  "env_logger",
  "flate2",
@@ -159,7 +166,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "structopt",
 ]
 
 [[package]]
@@ -412,12 +418,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -614,6 +617,15 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -894,33 +906,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -944,12 +932,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -978,28 +963,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "3", features = ["derive"] }
 cosmogony = { path = "cosmogony" }
 env_logger = "0.9"
 flate2 = "1.0"
@@ -28,7 +29,6 @@ serde_derive = "1"
 serde_json = "1"
 serde = { version = "1", features = ["rc"] }
 serde_yaml = "0.8"
-structopt = "0.3"
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use clap::ErrorKind;
+use clap::Parser;
 use cosmogony::{file_format::OutputFormat, Cosmogony};
 use cosmogony_builder::{build_cosmogony, merger};
 use flate2::write::GzEncoder;
@@ -6,8 +8,6 @@ use flate2::Compression;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
-use structopt::clap::ErrorKind;
-use structopt::StructOpt;
 
 /// Cosmogony arguments
 ///
@@ -21,30 +21,31 @@ use structopt::StructOpt;
 ///
 /// So `cosmogony -i <osm-file> -o output file` if the same as
 /// `cosmogony generate -i <osm-file> -o output file`
-#[derive(StructOpt, Debug)]
+#[derive(Debug, clap::Parser)]
+#[clap(version)]
 enum Args {
     /// Generate cosmogony subcommand
     ///
     /// Note: for retrocompatibility this is also the default subcommand if none is provided
-    #[structopt(name = "generate")]
+    #[clap(name = "generate")]
     Generate(GenerateArgs),
     /// Merge cosmogony subcommand
     ///
     /// Use it to merge several streamed cosmogony files into one.
     /// Can be useful to split the processing of a large osm file (like the planet)
     /// into several non overlapping small ones
-    #[structopt(name = "merge")]
+    #[clap(name = "merge")]
     Merge(MergeArgs),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, clap::Parser)]
 struct GenerateArgs {
     /// OSM PBF file.
-    #[structopt(short = "i", long = "input")]
+    #[clap(short = 'i', long = "input")]
     input: String,
     /// output file name
-    #[structopt(
-        short = "o",
+    #[clap(
+        short = 'o',
         long = "output",
         default_value = "cosmogony.json",
         help = r#"Output file name. Format will be deduced from the file extension. 
@@ -53,30 +54,30 @@ Accepted extensions are '.json', '.json.gz', '.jsonl', '.jsonl.gz'
 "#
     )]
     output: String,
-    #[structopt(help = "Do not display the stats", long = "no-stats")]
+    #[clap(help = "Do not display the stats", long = "no-stats")]
     no_stats: bool,
-    #[structopt(
+    #[clap(
         help = "country code if the pbf file does not contains any country",
         long = "country-code"
     )]
     country_code: Option<String>,
-    #[structopt(
+    #[clap(
         help = "Prevent voronoi geometries computation and generation",
         long = "disable-voronoi"
     )]
     disable_voronoi: bool,
-    #[structopt(help = "Only generates labels for given langs", long = "filter-langs")]
+    #[clap(help = "Only generates labels for given langs", long = "filter-langs")]
     filter_langs: Vec<String>,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, clap::Parser)]
 struct MergeArgs {
     /// Cosmogony files to process
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     files: Vec<PathBuf>,
     /// output file name
-    #[structopt(
-        short = "o",
+    #[clap(
+        short = 'o',
         long = "output",
         default_value = "cosmogony.jsonl",
         help = r#"Output file name. Format will be deduced from the file extension.
@@ -167,16 +168,16 @@ fn main() {
     init_logger();
     // Note: for retrocompatibility, we also try to read the args without subcommand
     // to generate a cosmogony
-    let args = GenerateArgs::from_args_safe()
+    let args = GenerateArgs::try_parse()
         .map(Args::Generate)
         .unwrap_or_else(|err| {
-            if let ErrorKind::VersionDisplayed = err.kind {
+            if let ErrorKind::DisplayVersion = err.kind() {
                 // The version number has been displayed.
                 // Args should not be parsed a second time.
                 println!();
                 std::process::exit(0)
             }
-            Args::from_args()
+            Args::parse()
         });
     if let Err(e) = run(args) {
         log::error!("cosmogony in error! {:?}", e);

--- a/src/country_finder.rs
+++ b/src/country_finder.rs
@@ -10,16 +10,9 @@ pub struct Country {
     admin_level: Option<u32>,
 }
 
+#[derive(Default)]
 pub struct CountryFinder {
     countries: BTreeMap<ZoneIndex, Country>,
-}
-
-impl Default for CountryFinder {
-    fn default() -> Self {
-        CountryFinder {
-            countries: BTreeMap::new(),
-        }
-    }
 }
 
 impl CountryFinder {

--- a/src/country_finder.rs
+++ b/src/country_finder.rs
@@ -10,7 +10,6 @@ pub struct Country {
     admin_level: Option<u32>,
 }
 
-#[derive(Default)]
 pub struct CountryFinder {
     countries: BTreeMap<ZoneIndex, Country>,
 }

--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -49,9 +49,9 @@ impl ZoneExt for Zone {
     fn from_osm_node(node: &Node, index: ZoneIndex) -> Option<Self> {
         let osm_id = OsmId::Node(node.id);
         let osm_id_str = match osm_id {
-            OsmId::Node(n) => format!("node:{}", n.0.to_string()),
-            OsmId::Relation(r) => format!("relation:{}", r.0.to_string()),
-            OsmId::Way(r) => format!("way:{}", r.0.to_string()),
+            OsmId::Node(n) => format!("node:{}", n.0),
+            OsmId::Relation(r) => format!("relation:{}", r.0),
+            OsmId::Way(r) => format!("way:{}", r.0),
         };
         let tags = &node.tags;
         let name = match tags.get("name") {
@@ -136,7 +136,7 @@ impl ZoneExt for Zone {
             .collect();
         let wikidata = relation.tags.get("wikidata").map(|s| s.to_string());
 
-        let osm_id = format!("relation:{}", relation.id.0.to_string());
+        let osm_id = format!("relation:{}", relation.id.0);
 
         let label_node = relation
             .refs

--- a/src/zone_typer.rs
+++ b/src/zone_typer.rs
@@ -209,18 +209,16 @@ impl From<SerdeRulesOverrides> for RulesOverrides {
             .contained_by
             .into_iter()
             .flat_map(|(osm_type, map)| {
-                map.into_iter().map(move |(osm_id, rules)| {
-                    (format!("{}:{}", osm_type.to_string(), osm_id), rules)
-                })
+                map.into_iter()
+                    .map(move |(osm_id, rules)| (format!("{}:{}", osm_type, osm_id), rules))
             })
             .collect();
         let i = serde
             .id_rules
             .into_iter()
             .flat_map(|(osm_type, map)| {
-                map.into_iter().map(move |(osm_id, rules)| {
-                    (format!("{}:{}", osm_type.to_string(), osm_id), rules)
-                })
+                map.into_iter()
+                    .map(move |(osm_id, rules)| (format!("{}:{}", osm_type, osm_id), rules))
             })
             .collect();
         RulesOverrides {
@@ -428,7 +426,7 @@ mod test {
         let mut make_zone = |id: &str, lvl| {
             let z = Zone {
                 id: ZoneIndex { index: idx },
-                osm_id: format!("relation:{}", id.to_string()),
+                osm_id: format!("relation:{}", id),
                 admin_level: lvl,
                 ..Default::default()
             };


### PR DESCRIPTION
Structopt is now in maintenance mode as all its features have been stabilized in clap, so no need for fragmentation here: https://github.com/TeXitoi/structopt#maintenance.

Also fixes a few clippy lints.