### PR TITLE
allow filter-langs parameter to contain comma-separated values

### DIFF
--- a/src/bin/cosmogony.rs
+++ b/src/bin/cosmogony.rs
@@ -65,8 +65,20 @@ Accepted extensions are '.json', '.json.gz', '.jsonl', '.jsonl.gz'
         long = "disable-voronoi"
     )]
     disable_voronoi: bool,
-    #[structopt(help = "Only generates labels for given langs", long = "filter-langs")]
-    filter_langs: Vec<String>,
+    #[structopt(
+        help = "Only generates labels for given langs. Either repeat parameter or use comma-separated value",
+        long = "filter-langs"
+    )]
+    filter_langs_raw: Vec<String>,
+}
+
+impl GenerateArgs {
+    fn filter_langs(&self) -> Vec<String> {
+        self.filter_langs_raw
+            .iter()
+            .flat_map(|val| val.split(',').map(String::from))
+            .collect()
+    }
 }
 
 #[derive(StructOpt, Debug)]
@@ -127,12 +139,13 @@ fn serialize_cosmogony(
 
 fn cosmogony(args: GenerateArgs) -> Result<()> {
     let format = OutputFormat::from_filename(&args.output)?;
+    let filter_langs = args.filter_langs();
 
     let cosmogony = build_cosmogony(
         args.input,
         args.country_code,
         args.disable_voronoi,
-        &args.filter_langs,
+        &filter_langs,
     )?;
 
     serialize_cosmogony(&cosmogony, args.output, format)?;


### PR DESCRIPTION
This should help orchestration with argo, which is currently painful as you can't easily generate advanced parameter structures.