### PR TITLE
add a buffer arround input file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmogony_builder"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["Adrien Matissart <a.matissart@qwantresearch.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/osm-without-borders/cosmogony"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,14 @@ use log::{debug, info};
 use osmpbfreader::{OsmId, OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::io::BufReader;
 use std::path::Path;
 
 use cosmogony::{Zone, ZoneIndex};
 
 use crate::zone_ext::ZoneExt;
+
+const FILE_BUF_SIZE: usize = 1024 * 1024; // 1MB
 
 #[rustfmt::skip]
 pub fn is_admin(obj: &OsmObj) -> bool {
@@ -223,6 +226,7 @@ pub fn build_cosmogony(
     let path = Path::new(&pbf_path);
     info!("Reading pbf with geometries...");
     let file = File::open(&path).context("no pbf file")?;
+    let file = BufReader::with_capacity(FILE_BUF_SIZE, file);
 
     let parsed_pbf = OsmPbfReader::new(file)
         .get_objs_and_deps(|o| is_admin(o) || is_place(o))


### PR DESCRIPTION
We are doing unbuffered I/O while reading the input file, which can lead leads to very slow computation on some environments (in our case PVCs in a kube clusters). I didn't dig into specific details but I saw that osmpbfreader doesn't wrap the reader with a buffer and makes atomic reads which would lead to an I/O operation each (often just a u32).