### PR TITLE
Add missing suburbs

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN apt-get update && apt-get install -y libgeos-c1v5 libgeos-dev && apt-get cle
 
 COPY . ./
 
-RUN cargo build --profile production
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/srv/cosmogony/target \
+    cargo build --profile production
+
+RUN --mount=type=cache,target=/srv/cosmogony/target  \
+    cp target/production/cosmogony cosmogony.bin
 
 FROM debian:buster-slim
 
@@ -16,6 +21,6 @@ WORKDIR /srv
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y libgeos-c1v5 libgeos-dev && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=builder /srv/cosmogony/target/production/cosmogony /usr/bin/cosmogony
+COPY --from=builder /srv/cosmogony/cosmogony.bin /usr/bin/cosmogony
 
 ENTRYPOINT ["cosmogony"]

--- a/cosmogony/src/read.rs
+++ b/cosmogony/src/read.rs
@@ -9,7 +9,7 @@ fn read_zones(
 ) -> impl std::iter::Iterator<Item = Result<Zone, Error>> {
     reader
         .lines()
-        .map(|l| l.map_err(|err| anyhow!("{}", err)))
+        .map(|l| l.map_err(|err| err.into()))
         .map(|l| l.and_then(|l| serde_json::from_str(&l).map_err(|err| anyhow!("{}", err))))
 }
 

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -38,7 +38,7 @@ impl ZoneType {
 
     pub fn parse(s: &str) -> Option<Self> {
         Some(match s {
-            "suburb" => Self::Suburb,
+            "suburb" | "quarter" | "neighbourhood" => Self::Suburb,
             "city_district" => Self::CityDistrict,
             "city" | "town" | "village" => Self::City,
             "state_district" => Self::StateDistrict,

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -40,7 +40,7 @@ impl ZoneType {
         Some(match s {
             "suburb" => Self::Suburb,
             "city_district" => Self::CityDistrict,
-            "city" => Self::City,
+            "city" | "town" | "village" => Self::City,
             "state_district" => Self::StateDistrict,
             "state" => Self::State,
             "country_region" => Self::CountryRegion,

--- a/cosmogony/src/zone.rs
+++ b/cosmogony/src/zone.rs
@@ -35,6 +35,20 @@ impl ZoneType {
             ZoneType::NonAdministrative => "non_administrative",
         }
     }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "suburb" => Self::Suburb,
+            "city_district" => Self::CityDistrict,
+            "city" => Self::City,
+            "state_district" => Self::StateDistrict,
+            "state" => Self::State,
+            "country_region" => Self::CountryRegion,
+            "country" => Self::Country,
+            "non_administrative" => Self::NonAdministrative,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Copy, Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -30,12 +30,13 @@ fn difference<'a>(g: &geos::Geometry<'a>, other: &Zone) -> Option<geos::Geometry
     }
 }
 
-pub fn compute_additional_cities(
+pub fn compute_additional_places(
     zones: &mut Vec<Zone>,
     parsed_pbf: &BTreeMap<OsmId, OsmObj>,
     zones_rtree: ZonesTree,
 ) {
     let place_zones = read_places(parsed_pbf);
+
     info!(
         "there are {} places, we'll try to make boundaries for them",
         place_zones.len()

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -242,7 +242,7 @@ fn get_places_to_subtract<'a>(
         .map(|z_idx| &zones[z_idx.index])
         .filter(|z| {
             z.admin_type()
-                .map(|zt| zt <= ZoneType::City || z.parent == Some(*parent_id))
+                .map(|zt| Some(zt) == zone.zone_type || z.parent == Some(*parent_id))
                 .unwrap_or(false)
         })
         .filter(|z| zone.intersects(z))

--- a/src/additional_zones.rs
+++ b/src/additional_zones.rs
@@ -50,10 +50,6 @@ pub fn compute_additional_places(
             get_parent(place, zones, &zones_rtree).map(|parent| (parent, place))
         })
         .filter(|(parent, place)| {
-            if place.name == "Cité Internationale" {
-                dbg!(&parent, &place);
-            }
-
             (parent.zone_type)
                 .map(|parent_zone| {
                     if parent_zone == ZoneType::Country {
@@ -63,7 +59,11 @@ pub fn compute_additional_places(
                         );
                     }
 
-                    parent_zone < ZoneType::Country
+                    // Ensuring zones are stricly increasing also ensures there will be no
+                    // duplicates, for example by adding an admin label which is inside its
+                    // boundary.
+                    parent_zone > place.zone_type.unwrap_or(parent_zone)
+                        && parent_zone < ZoneType::Country
                 })
                 .unwrap_or(false)
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod zone_typer;
 
 use crate::country_finder::CountryFinder;
 use crate::hierarchy_builder::{build_hierarchy, find_inclusions};
-use additional_zones::compute_additional_cities;
+use additional_zones::compute_additional_places;
 use anyhow::{anyhow, Context, Error};
 use cosmogony::mutable_slice::MutableSlice;
 use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
@@ -43,10 +43,10 @@ pub fn is_admin(obj: &OsmObj) -> bool {
 
 pub fn is_place(obj: &OsmObj) -> bool {
     match *obj {
-        OsmObj::Node(ref node) => node
-            .tags
-            .get("place")
-            .map_or(false, |v| v == "city" || v == "town" || v == "village"),
+        OsmObj::Node(ref node) => matches!(
+            node.tags.get("place").map(|s| s.as_str()),
+            Some("city" | "town" | "village" | "suburb")
+        ),
         _ => false,
     }
 }
@@ -197,7 +197,7 @@ pub fn create_ontology(
     build_hierarchy(zones, inclusions);
 
     if !disable_voronoi {
-        compute_additional_cities(zones, parsed_pbf, ztree);
+        compute_additional_places(zones, parsed_pbf, ztree);
     }
 
     zones.iter_mut().for_each(|z| z.compute_names());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use crate::hierarchy_builder::{build_hierarchy, find_inclusions};
 use additional_zones::compute_additional_places;
 use anyhow::{anyhow, Context, Error};
 use cosmogony::mutable_slice::MutableSlice;
-use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats};
+use cosmogony::{Cosmogony, CosmogonyMetadata, CosmogonyStats, ZoneType};
 use log::{debug, info};
 use osmpbfreader::{OsmId, OsmObj, OsmPbfReader};
 use std::collections::BTreeMap;
@@ -44,8 +44,8 @@ pub fn is_admin(obj: &OsmObj) -> bool {
 pub fn is_place(obj: &OsmObj) -> bool {
     match *obj {
         OsmObj::Node(ref node) => matches!(
-            node.tags.get("place").map(|s| s.as_str()),
-            Some("city" | "town" | "village" | "suburb")
+            node.tags.get("place").and_then(|s| ZoneType::parse(s)),
+            Some(ZoneType::City | ZoneType::Suburb)
         ),
         _ => false,
     }

--- a/src/zone_ext.rs
+++ b/src/zone_ext.rs
@@ -85,12 +85,17 @@ impl ZoneExt for Zone {
             .map(|s| s.to_string())
             .unwrap_or_else(|| "".to_string());
 
+        let zone_type = tags
+            .get("place")
+            .map(|s| s.as_str())
+            .and_then(ZoneType::parse);
+
         let international_names = get_international_names(tags, name);
         Some(Self {
             id: index,
             osm_id: osm_id_str,
             admin_level: level,
-            zone_type: None,
+            zone_type,
             name: name.to_string(),
             loc_name,
             alt_name,

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -43,7 +43,7 @@ fn test_cmd_with_json_output() {
     assert!(output.status.success());
 
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 299);
+    assert_eq!(cosmo.zones.len(), 675);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_cmd_with_json_stream_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 299);
+    assert_eq!(zones.count(), 675);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_cmd_with_json_stream_gz_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 299);
+    assert_eq!(zones.count(), 675);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_cmd_with_json_gz_output() {
     ]);
     assert!(output.status.success());
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 299);
+    assert_eq!(cosmo.zones.len(), 675);
 }
 
 #[test]
@@ -329,5 +329,5 @@ fn test_voronoi() {
     assert_eq!(zones.len(), 118);
     create_ontology(&mut zones, &mut stats, None, false, &parsed_pbf, &[])
         .expect("create_ontology failed");
-    assert_eq!(zones.len(), 4453);
+    assert_eq!(zones.len(), 4500);
 }

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -42,8 +42,8 @@ fn test_cmd_with_json_output() {
     ]);
     assert!(output.status.success());
 
-    let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 674);
+    let cosmo = cosmogony::load_cosmogony_from_file(out_file).unwrap();
+    assert_eq!(cosmo.zones.len(), 208);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_cmd_with_json_stream_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 674);
+    assert_eq!(zones.count(), 208);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_cmd_with_json_stream_gz_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 674);
+    assert_eq!(zones.count(), 208);
 }
 
 #[test]
@@ -88,8 +88,8 @@ fn test_cmd_with_json_gz_output() {
         out_file,
     ]);
     assert!(output.status.success());
-    let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 674);
+    let cosmo = cosmogony::load_cosmogony_from_file(out_file).unwrap();
+    assert_eq!(cosmo.zones.len(), 208);
 }
 
 #[test]
@@ -317,7 +317,7 @@ fn test_voronoi() {
         "/../../../../../tests/data/ivory-coast.pbf"
     );
     let path = Path::new(&ivory_test_file);
-    let file = File::open(&path).expect("no pbf file");
+    let file = File::open(path).expect("no pbf file");
 
     let parsed_pbf = OsmPbfReader::new(file)
         .get_objs_and_deps(|o| is_admin(o) || is_place(o))
@@ -329,5 +329,5 @@ fn test_voronoi() {
     assert_eq!(zones.len(), 118);
     create_ontology(&mut zones, &mut stats, None, false, &parsed_pbf, &[])
         .expect("create_ontology failed");
-    assert_eq!(zones.len(), 4500);
+    assert_eq!(zones.len(), 4471);
 }

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -43,7 +43,7 @@ fn test_cmd_with_json_output() {
     assert!(output.status.success());
 
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 675);
+    assert_eq!(cosmo.zones.len(), 674);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_cmd_with_json_stream_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 675);
+    assert_eq!(zones.count(), 674);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_cmd_with_json_stream_gz_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 675);
+    assert_eq!(zones.count(), 674);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_cmd_with_json_gz_output() {
     ]);
     assert!(output.status.success());
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 675);
+    assert_eq!(cosmo.zones.len(), 674);
 }
 
 #[test]

--- a/tests/cosmogony_test.rs
+++ b/tests/cosmogony_test.rs
@@ -3,13 +3,13 @@ extern crate approx;
 
 use cosmogony::{Cosmogony, Zone, ZoneIndex, ZoneType};
 use cosmogony_builder::{create_ontology, get_zones_and_stats, is_admin, is_place};
+use geo_types::Point;
 use osmpbfreader::OsmPbfReader;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::Path;
 use std::process::{Command, Output};
 
-use geo_types::Point;
 type Coord = Point<f64>;
 
 fn launch_command_line(args: Vec<&str>) -> Output {
@@ -43,7 +43,7 @@ fn test_cmd_with_json_output() {
     assert!(output.status.success());
 
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 195);
+    assert_eq!(cosmo.zones.len(), 299);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_cmd_with_json_stream_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 195);
+    assert_eq!(zones.count(), 299);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_cmd_with_json_stream_gz_output() {
 
     // we try also the streaming zone's reader
     let zones = cosmogony::read_zones_from_file(out_file).unwrap();
-    assert_eq!(zones.count(), 195);
+    assert_eq!(zones.count(), 299);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn test_cmd_with_json_gz_output() {
     ]);
     assert!(output.status.success());
     let cosmo = cosmogony::load_cosmogony_from_file(&out_file).unwrap();
-    assert_eq!(cosmo.zones.len(), 195);
+    assert_eq!(cosmo.zones.len(), 299);
 }
 
 #[test]
@@ -329,5 +329,5 @@ fn test_voronoi() {
     assert_eq!(zones.len(), 118);
     create_ontology(&mut zones, &mut stats, None, false, &parsed_pbf, &[])
         .expect("create_ontology failed");
-    assert_eq!(zones.len(), 4449);
+    assert_eq!(zones.len(), 4453);
 }


### PR DESCRIPTION
Some suburbs are not imported, when they are attached to a node and not a relation.

This PR mainly changes the filter `is_place` to add suburbs together with towns and villages, and fixes a few things that were not general enough to support this change.