### PR TITLE
upgrade dependency geo-types to version 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d77ceb80f375dc4cda113a3ae1b06a36ef623f8f035c03752ca6698f4ddfee"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
 dependencies = [
  "approx",
  "num-traits",


### PR DESCRIPTION
Cosmogony can't compile with geo-types version 0.7.7.

Described here:
https://github.com/osm-without-borders/cosmogony/issues/152

This Pull Request is here to address this issue.